### PR TITLE
[Refactor] Correct behaviour of CSWAP constructor

### DIFF
--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -28,16 +28,16 @@ class Parametric(Primitive):
         self.register_buffer("identity", OPERATIONS_DICT["I"])
         self.param_name = param_name
 
-        def parse_values(values: dict[str, torch.Tensor] | torch.Tensor = {}) -> torch.Tensor:
+        def parse_values(values: dict[str, torch.Tensor] | torch.Tensor = dict()) -> torch.Tensor:
             return Parametric._expand_values(values[self.param_name])
 
-        def parse_tensor(values: dict[str, torch.Tensor] | torch.Tensor = {}) -> torch.Tensor:
+        def parse_tensor(values: dict[str, torch.Tensor] | torch.Tensor = dict()) -> torch.Tensor:
             return Parametric._expand_values(values)
 
         self.parse_values = parse_tensor if param_name == "" else parse_values
 
     def extra_repr(self) -> str:
-        return f"{self.qubit_support}, {self.param_name}"
+        return f"target:{self.qubit_support}, param:{self.param_name}"
 
     def __hash__(self) -> int:
         return hash(self.qubit_support) + hash(self.param_name)
@@ -112,7 +112,12 @@ class ControlledRotationGate(Parametric):
     ):
         self.control = control if isinstance(control, tuple) else (control,)
         super().__init__(gate, target, param_name)
-        self.qubit_support = self.control + (self.target,)  # type: ignore
+        self.qubit_support = self.control + (self.target,)  # type: ignore[operator]
+        # In this class, target is always an int but herit from Parametric and Primitive that:
+        # target : int | tuple[int,...]
+
+    def extra_repr(self) -> str:
+        return f"target: {self.control}, target:{(self.target,)}, param:{self.param_name}"
 
     def unitary(self, values: dict[str, torch.Tensor] = {}) -> Operator:
         thetas = self.parse_values(values)

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -112,7 +112,7 @@ class ControlledRotationGate(Parametric):
     ):
         self.control = control if isinstance(control, tuple) else (control,)
         super().__init__(gate, target, param_name)
-        self.qubit_support = self.control + (self.target,)
+        self.qubit_support = self.control + (self.target,)  # type: ignore
 
     def unitary(self, values: dict[str, torch.Tensor] = {}) -> Operator:
         thetas = self.parse_values(values)

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Tuple
 
 import torch
+from torch import Tensor
 
 from pyqtorch.matrices import (
     DEFAULT_MATRIX_DTYPE,
@@ -28,10 +29,10 @@ class Parametric(Primitive):
         self.register_buffer("identity", OPERATIONS_DICT["I"])
         self.param_name = param_name
 
-        def parse_values(values: dict[str, torch.Tensor] | torch.Tensor = dict()) -> torch.Tensor:
+        def parse_values(values: dict[str, Tensor] | Tensor = dict()) -> Tensor:
             return Parametric._expand_values(values[self.param_name])
 
-        def parse_tensor(values: dict[str, torch.Tensor] | torch.Tensor = dict()) -> torch.Tensor:
+        def parse_tensor(values: dict[str, Tensor] | Tensor = dict()) -> Tensor:
             return Parametric._expand_values(values)
 
         self.parse_values = parse_tensor if param_name == "" else parse_values
@@ -43,15 +44,15 @@ class Parametric(Primitive):
         return hash(self.qubit_support) + hash(self.param_name)
 
     @staticmethod
-    def _expand_values(values: torch.Tensor) -> torch.Tensor:
+    def _expand_values(values: Tensor) -> Tensor:
         return values.unsqueeze(0) if len(values.size()) == 0 else values
 
-    def unitary(self, values: dict[str, torch.Tensor] | torch.Tensor = {}) -> Operator:
+    def unitary(self, values: dict[str, Tensor] | Tensor = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         return _unitary(thetas, self.pauli, self.identity, batch_size)
 
-    def jacobian(self, values: dict[str, torch.Tensor] | torch.Tensor = {}) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] | Tensor = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         return _jacobian(thetas, self.pauli, self.identity, batch_size)
@@ -84,14 +85,14 @@ class PHASE(Parametric):
     def __init__(self, target: int, param_name: str = ""):
         super().__init__("I", target, param_name)
 
-    def unitary(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         batch_mat = self.identity.unsqueeze(2).repeat(1, 1, batch_size)
         batch_mat[1, 1, :] = torch.exp(1.0j * thetas).unsqueeze(0).unsqueeze(1)
         return batch_mat
 
-    def jacobian(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_mat = (
             torch.zeros((2, 2), dtype=self.identity.dtype).unsqueeze(2).repeat(1, 1, len(thetas))
@@ -119,13 +120,13 @@ class ControlledRotationGate(Parametric):
     def extra_repr(self) -> str:
         return f"target: {self.control}, target:{(self.target,)}, param:{self.param_name}"
 
-    def unitary(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         mat = _unitary(thetas, self.pauli, self.identity, batch_size)
         return _controlled(mat, batch_size, len(self.control))
 
-    def jacobian(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         n_control = len(self.control)
@@ -182,14 +183,14 @@ class CPHASE(ControlledRotationGate):
     ):
         super().__init__("I", control, target, param_name)
 
-    def unitary(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         mat = self.identity.unsqueeze(2).repeat(1, 1, batch_size)
         mat[1, 1, :] = torch.exp(1.0j * thetas).unsqueeze(0).unsqueeze(1)
         return _controlled(mat, batch_size, len(self.control))
 
-    def jacobian(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = dict()) -> Operator:
         thetas = self.parse_values(values)
         batch_size = len(thetas)
         n_control = len(self.control)
@@ -233,7 +234,7 @@ class U(Parametric):
             "d", torch.tensor([[0, 0], [0, 1]], dtype=DEFAULT_MATRIX_DTYPE).unsqueeze(2)
         )
 
-    def unitary(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
         phi, theta, omega = list(
             map(
                 lambda t: t.unsqueeze(0) if len(t.size()) == 0 else t,
@@ -253,7 +254,7 @@ class U(Parametric):
         d = self.d.repeat(1, 1, batch_size) * cos_t * torch.conj(t_plus)
         return a - b + c + d
 
-    def jacobian(self, values: dict[str, torch.Tensor] = {}) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = {}) -> Operator:
         raise NotImplementedError
 
     def digital_decomposition(self) -> list[Parametric]:
@@ -263,5 +264,5 @@ class U(Parametric):
             RZ(self.qubit_support[0], self.omega),
         ]
 
-    def jacobian_decomposed(self, values: dict[str, torch.Tensor] = {}) -> list[Operator]:
+    def jacobian_decomposed(self, values: dict[str, Tensor] = dict()) -> list[Operator]:
         return [op.jacobian(values) for op in self.digital_decomposition()]

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -147,13 +147,13 @@ class SWAP(Primitive):
 
 
 class CSWAP(Primitive):
-    def __init__(self, control: tuple[int, ...], target: int):
-        if not isinstance(control, tuple) or len(control) < 2:
-            raise ValueError("Control qubits must be a tuple with two qubits")
+    def __init__(self, control: int | tuple[int, ...], target: tuple[int, ...]):
+        if not isinstance(target, tuple) or len(target) != 2:
+            raise ValueError("Target qubits must be a tuple with two qubits")
         super().__init__(OPERATIONS_DICT["CSWAP"], target)
         self.control = (control,) if isinstance(control, int) else control
         self.target = target
-        self.qubit_support = self.control + (target,)
+        self.qubit_support = self.control + target
 
 
 class ControlledOperationGate(Primitive):

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -31,10 +31,10 @@ def pre_backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
 
 
 class Primitive(torch.nn.Module):
-    def __init__(self, pauli: Tensor, target: int) -> None:
+    def __init__(self, pauli: Tensor, target: int | tuple[int, ...]) -> None:
         super().__init__()
-        self.target: int = target
-        self.qubit_support: tuple[int, ...] = (target,)
+        self.target: int | tuple[int, ...] = target
+        self.qubit_support: tuple[int, ...] = (target,) if isinstance(target, int) else target
         self.register_buffer("pauli", pauli)
         self._device = self.pauli.device
         self._dtype = self.pauli.dtype

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -153,7 +153,10 @@ class CSWAP(Primitive):
         super().__init__(OPERATIONS_DICT["CSWAP"], target)
         self.control = (control,) if isinstance(control, int) else control
         self.target = target
-        self.qubit_support = self.control + target
+        self.qubit_support = self.control + self.target
+
+    def extra_repr(self) -> str:
+        return f"control:{self.control}, target:{self.target}"
 
 
 class ControlledOperationGate(Primitive):
@@ -166,7 +169,10 @@ class ControlledOperationGate(Primitive):
             n_control_qubits=len(self.control),
         ).squeeze(2)
         super().__init__(mat, target)
-        self.qubit_support = self.control + (target,)
+        self.qubit_support = self.control + (self.target,)  # type: ignore[operator]
+
+    def extra_repr(self) -> str:
+        return f"control:{self.control}, target:{(self.target,)}"
 
 
 class CNOT(ControlledOperationGate):

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -147,7 +147,9 @@ class SWAP(Primitive):
 
 
 class CSWAP(Primitive):
-    def __init__(self, control: int | tuple[int, ...], target: int):
+    def __init__(self, control: tuple[int, ...], target: int):
+        if not isinstance(control, tuple) or len(control) < 2:
+            raise ValueError("Control qubits must be a tuple with two qubits")
         super().__init__(OPERATIONS_DICT["CSWAP"], target)
         self.control = (control,) if isinstance(control, int) else control
         self.target = target

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -64,7 +64,7 @@ def test_differentiate_circuit(dtype: torch.dtype, batch_size: int, n_qubits: in
         pyq.Y(1),
         pyq.RX(0, "theta_0"),
         pyq.PHASE(0, "theta_1"),
-        pyq.CSWAP(2, (0, 1)),
+        pyq.CSWAP(0, (1, 2)),
         pyq.CRX(1, 2, "theta_2"),
         pyq.CPHASE(1, 2, "theta_3"),
         pyq.CNOT(0, 1),

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -64,7 +64,7 @@ def test_differentiate_circuit(dtype: torch.dtype, batch_size: int, n_qubits: in
         pyq.Y(1),
         pyq.RX(0, "theta_0"),
         pyq.PHASE(0, "theta_1"),
-        pyq.CSWAP((0, 1), 2),
+        pyq.CSWAP(2, (0, 1)),
         pyq.CRX(1, 2, "theta_2"),
         pyq.CPHASE(1, 2, "theta_3"),
         pyq.CNOT(0, 1),

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -25,8 +25,9 @@ from pyqtorch.utils import (
 state_000 = product_state("000")
 state_001 = product_state("001")
 state_100 = product_state("100")
-state_101 = product_state("101")
+state_101 = product_state("101")  
 state_110 = product_state("110")
+state_011 = product_state("011") 
 state_111 = product_state("111")
 state_0000 = product_state("0000")
 state_1110 = product_state("1110")
@@ -150,12 +151,12 @@ def test_CRY_state01_controlqubit_0() -> None:
 
 
 def test_CSWAP_state101_controlqubit_0() -> None:
-    result: Tensor = pyq.CSWAP((0, 1), 2)(product_state("101"), None)
-    assert torch.allclose(product_state("110"), result)
+    result: Tensor = pyq.CSWAP(2, (0, 1))(product_state("101"), None)
+    assert torch.allclose(product_state("011"), result)
 
 
 def test_CSWAP_state110_controlqubit_0() -> None:
-    result: Tensor = pyq.CSWAP((0, 1), 2)(product_state("101"), None)
+    result: Tensor = pyq.CSWAP(2, (0, 1))(product_state("110"), None)
     assert torch.allclose(product_state("110"), result)
 
 
@@ -165,12 +166,12 @@ def test_CSWAP_state110_controlqubit_0() -> None:
         (state_000, state_000),
         (state_001, state_001),
         (state_100, state_100),
-        (state_101, state_110),
-        (state_110, state_101),
+        (state_101, state_011), 
+        (state_110, state_110), 
     ],
 )
 def test_CSWAP_controlqubits0(initial_state: Tensor, expected_state: Tensor) -> None:
-    cswap = pyq.CSWAP((0, 1), 2)
+    cswap = pyq.CSWAP(2, (0, 1))
     assert torch.allclose(cswap(initial_state, None), expected_state)
 
 

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -150,28 +150,18 @@ def test_CRY_state01_controlqubit_0() -> None:
     assert torch.allclose(product_state("11"), result, atol=ATOL)
 
 
-def test_CSWAP_state101_controlqubit_0() -> None:
-    result: Tensor = pyq.CSWAP(2, (0, 1))(product_state("101"), None)
-    assert torch.allclose(product_state("011"), result)
-
-
-def test_CSWAP_state110_controlqubit_0() -> None:
-    result: Tensor = pyq.CSWAP(2, (0, 1))(product_state("110"), None)
-    assert torch.allclose(product_state("110"), result)
-
-
 @pytest.mark.parametrize(
     "initial_state,expected_state",
     [
         (state_000, state_000),
         (state_001, state_001),
         (state_100, state_100),
-        (state_101, state_011),
-        (state_110, state_110),
+        (state_101, state_110),
+        (state_110, state_101),
     ],
 )
 def test_CSWAP_controlqubits0(initial_state: Tensor, expected_state: Tensor) -> None:
-    cswap = pyq.CSWAP(2, (0, 1))
+    cswap = pyq.CSWAP(0, (1, 2))
     assert torch.allclose(cswap(initial_state, None), expected_state)
 
 

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -25,9 +25,9 @@ from pyqtorch.utils import (
 state_000 = product_state("000")
 state_001 = product_state("001")
 state_100 = product_state("100")
-state_101 = product_state("101")  
+state_101 = product_state("101")
 state_110 = product_state("110")
-state_011 = product_state("011") 
+state_011 = product_state("011")
 state_111 = product_state("111")
 state_0000 = product_state("0000")
 state_1110 = product_state("1110")
@@ -166,8 +166,8 @@ def test_CSWAP_state110_controlqubit_0() -> None:
         (state_000, state_000),
         (state_001, state_001),
         (state_100, state_100),
-        (state_101, state_011), 
-        (state_110, state_110), 
+        (state_101, state_011),
+        (state_110, state_110),
     ],
 )
 def test_CSWAP_controlqubits0(initial_state: Tensor, expected_state: Tensor) -> None:


### PR DESCRIPTION
- [x] Update `CSWAP` gate parameter requirement to only accept tuples as target, not integers, and added error handling for clarity.
- [x] Change the gates `extra_repr` method for more clarity .
- [x]  Check the behavior in `Qadence` after the modifcation of `extra_repr`

Closes #180.
Closes #184.