### PR TITLE
[Fix] Handle nested param dicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 requires-python = ">=3.8,<3.13"
 license = {text = "Apache 2.0"}
-version = "1.2.3"
+version = "1.2.4"
 classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -247,7 +247,17 @@ class Merge(Sequence):
     def forward(self, state: Tensor, values: dict[str, Tensor] | None = None) -> Tensor:
         batch_size = state.shape[-1]
         if values:
-            batch_size = max(batch_size, max(list(map(len, values.values()))))
+            batch_size = max(
+                batch_size,
+                max(
+                    list(
+                        map(
+                            lambda t: len(t) if isinstance(t, Tensor) else 1,
+                            values.values(),
+                        )
+                    )
+                ),
+            )
         return apply_operator(
             state,
             self.unitary(values, batch_size),

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -220,6 +220,14 @@ def test_merge_different_batchsize(batch_size: int) -> None:
         mergecirc(pyq.random_state(2, batch_size), {"theta_0": torch.rand(bs)})
 
 
+def test_merge_nested_dict() -> None:
+    ops = [pyq.X(0), pyq.RX(0, "theta_0")]
+    mergecirc = pyq.Merge(ops)
+    vals = {"theta_0": torch.rand(2), "theta_2": torch.rand(2)}
+    vals["nested"] = vals
+    mergecirc(pyq.random_state(2), vals)
+
+
 @pytest.mark.xfail  # investigate
 @pytest.mark.parametrize("dtype", [torch.complex64, torch.complex128])
 @pytest.mark.parametrize("batch_size", [1, 5])

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -223,7 +223,11 @@ def test_merge_different_batchsize(batch_size: int) -> None:
 def test_merge_nested_dict() -> None:
     ops = [pyq.X(0), pyq.RX(0, "theta_0")]
     mergecirc = pyq.Merge(ops)
-    vals = {"theta_0": torch.rand(2), "theta_2": torch.rand(2)}
+    vals = {
+        "theta_0": torch.rand(1),
+        "theta_2": torch.rand(2),
+        "theta_3": torch.rand(2),
+    }
     vals["nested"] = vals
     mergecirc(pyq.random_state(2), vals)
 


### PR DESCRIPTION
avoid inferring batch_sizes from the length of dicts as values