### PR TITLE
[Refactoring, Hamevo] Optimize block_to_tensor calls for repeated execution of HamEvo

### DIFF
--- a/pyqtorch/analog.py
+++ b/pyqtorch/analog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import OrderedDict
 from functools import reduce
 from logging import getLogger
 from operator import add
@@ -472,6 +473,7 @@ class HamiltonianEvolution(Sequence):
             qubit_support: The qubits the operator acts on.
             generator_parametric: Whether the generator is parametric or not.
         """
+
         if isinstance(generator, Tensor):
             assert (
                 qubit_support is not None
@@ -532,6 +534,9 @@ class HamiltonianEvolution(Sequence):
             GeneratorType.OPERATION: self._tensor_generator,
             GeneratorType.PARAMETRIC_OPERATION: self._parametric_generator,
         }
+
+        # to avoid recomputing hamiltonians and evolution
+        self._cache_hamiltonian_evo: dict[str, Tensor] = {}
 
     @property
     def generator(self) -> ModuleList:
@@ -607,17 +612,14 @@ class HamiltonianEvolution(Sequence):
         Returns:
             The transformed state.
         """
-        hamiltonian: torch.Tensor = self.create_hamiltonian(values)
-        time_evolution: torch.Tensor = (
-            values[self.time] if isinstance(self.time, str) else self.time
-        )  # If `self.time` is a string / hence, a Parameter,
-        # we expect the user to pass it in the `values` dict
+
+        evolved_op = self.tensor(values, None)
         return apply_operator(
             state=state,
-            operator=evolve(hamiltonian, time_evolution),
+            operator=evolved_op,
             qubits=self.qubit_support,
             n_qubits=len(state.size()) - 1,
-            batch_size=max(hamiltonian.shape[BATCH_DIM], len(time_evolution)),
+            batch_size=evolved_op.shape[BATCH_DIM],
         )
 
     def tensor(
@@ -640,6 +642,11 @@ class HamiltonianEvolution(Sequence):
         Raises:
             NotImplementedError for the diagonal case.
         """
+
+        values_cache_key = str(OrderedDict(values))
+        if values_cache_key in self._cache_hamiltonian_evo:
+            return self._cache_hamiltonian_evo[values_cache_key]
+
         if diagonal:
             raise NotImplementedError
         if n_qubits is None:
@@ -647,5 +654,8 @@ class HamiltonianEvolution(Sequence):
         hamiltonian: torch.Tensor = self.create_hamiltonian(values)
         time_evolution: torch.Tensor = (
             values[self.time] if isinstance(self.time, str) else self.time
-        )
-        return evolve(hamiltonian, time_evolution)
+        )  # If `self.time` is a string / hence, a Parameter,
+        # we expect the user to pass it in the `values` dict
+        evolved_op = evolve(hamiltonian, time_evolution)
+        self._cache_hamiltonian_evo[values_cache_key] = evolved_op
+        return evolved_op

--- a/pyqtorch/analog.py
+++ b/pyqtorch/analog.py
@@ -536,7 +536,7 @@ class HamiltonianEvolution(Sequence):
         }
 
         # to avoid recomputing hamiltonians and evolution
-        self._cache_hamiltonian_evo: dict[str, Tensor] = {}
+        self._cache_hamiltonian_evo: dict[str, Tensor] = dict()
 
     @property
     def generator(self) -> ModuleList:

--- a/pyqtorch/analog.py
+++ b/pyqtorch/analog.py
@@ -630,6 +630,8 @@ class HamiltonianEvolution(Sequence):
     ) -> Operator:
         """Get the corresponding unitary over n_qubits.
 
+        To avoid computing the evolution operator, we store it in cache wrt values.
+
         Arguments:
             values: Parameter value.
             n_qubits: The number of qubits the unitary is represented over.

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -152,8 +152,10 @@ def test_hamiltonianevolution_with_types(
 
     # test cached
     assert len(hamevo._cache_hamiltonian_evo) == 1
+
     psi_star = hamevo(psi)
     assert len(hamevo._cache_hamiltonian_evo) == 1
+    result = overlap(psi_star, psi)
     # check value has not changed
     assert torch.allclose(result, target, rtol=RTOL, atol=ATOL)
 

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -152,6 +152,8 @@ def test_hamiltonianevolution_with_types(
     assert len(hamevo._cache_hamiltonian_evo) == 1
     psi_star = hamevo(psi)
     assert len(hamevo._cache_hamiltonian_evo) == 1
+    # check value has not changed
+    assert torch.allclose(result, target, rtol=RTOL, atol=ATOL)
 
 
 @pytest.mark.parametrize("n_qubits", [2, 4, 6])
@@ -175,12 +177,20 @@ def test_hamevo_parametric_gen(n_qubits: int) -> None:
     assert len(hamevo._cache_hamiltonian_evo) == 1
     psi_star = hamevo(psi, vals)
     assert len(hamevo._cache_hamiltonian_evo) == 1
+    # check for same result
+    assert torch.allclose(psi_star, psi_expected, rtol=RTOL, atol=ATOL)
+
     vals[vparam] += 0.1
     psi_star = hamevo(psi, vals)
+    psi_expected = _calc_mat_vec_wavefunction(hamevo, n_qubits, psi, vals)
     assert len(hamevo._cache_hamiltonian_evo) == 2
+    assert torch.allclose(psi_star, psi_expected, rtol=RTOL, atol=ATOL)
+
     psi = random_state(n_qubits)
     psi_star = hamevo(psi, vals)
+    psi_expected = _calc_mat_vec_wavefunction(hamevo, n_qubits, psi, vals)
     assert len(hamevo._cache_hamiltonian_evo) == 2
+    assert torch.allclose(psi_star, psi_expected, rtol=RTOL, atol=ATOL)
 
 
 def test_hevo_constant_gen() -> None:

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -148,6 +148,11 @@ def test_hamiltonianevolution_with_types(
     assert result.size() == (batch_size,)
     assert torch.allclose(result, target, rtol=RTOL, atol=ATOL)
 
+    # test cached
+    assert len(hamevo._cache_hamiltonian_evo) == 1
+    psi_star = hamevo(psi)
+    assert len(hamevo._cache_hamiltonian_evo) == 1
+
 
 @pytest.mark.parametrize("n_qubits", [2, 4, 6])
 def test_hamevo_parametric_gen(n_qubits: int) -> None:
@@ -165,6 +170,14 @@ def test_hamevo_parametric_gen(n_qubits: int) -> None:
     psi_star = hamevo(psi, vals)
     psi_expected = _calc_mat_vec_wavefunction(hamevo, n_qubits, psi, vals)
     assert torch.allclose(psi_star, psi_expected, rtol=RTOL, atol=ATOL)
+
+    # test cached
+    assert len(hamevo._cache_hamiltonian_evo) == 1
+    psi_star = hamevo(psi, vals)
+    assert len(hamevo._cache_hamiltonian_evo) == 1
+    vals[vparam] += 0.1
+    psi_star = hamevo(psi, vals)
+    assert len(hamevo._cache_hamiltonian_evo) == 2
 
 
 def test_hevo_constant_gen() -> None:

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -178,6 +178,9 @@ def test_hamevo_parametric_gen(n_qubits: int) -> None:
     vals[vparam] += 0.1
     psi_star = hamevo(psi, vals)
     assert len(hamevo._cache_hamiltonian_evo) == 2
+    psi = random_state(n_qubits)
+    psi_star = hamevo(psi, vals)
+    assert len(hamevo._cache_hamiltonian_evo) == 2
 
 
 def test_hevo_constant_gen() -> None:


### PR DESCRIPTION
Avoid recomputing the evolution operator via a simple caching system. Related to issue #176 