### PR TITLE
[Bug] Fix GPSR with repeated params

### DIFF
--- a/pyqtorch/gpsr.py
+++ b/pyqtorch/gpsr.py
@@ -111,17 +111,23 @@ class PSRExpectation(Function):
 
                 if values[op.param_name].requires_grad:
                     with no_grad():
+                        # to handle repeated parameter cases in circuit
+                        original_name = op.param_name
+                        temp_name = op.param_name + "_temp"
                         copied_values = values.copy()
-                        copied_values[op.param_name] += shift
+                        copied_values[temp_name] = copied_values[original_name] + shift
+                        op.param_name = temp_name
+
                         f_plus = pyq.expectation(
                             ctx.circuit, ctx.state, copied_values, ctx.observable
                         )
-                        copied_values[op.param_name] -= 2.0 * shift
+                        copied_values[temp_name] -= 2.0 * shift
                         f_min = pyq.expectation(
                             ctx.circuit, ctx.state, copied_values, ctx.observable
                         )
                         # reset values
-                        copied_values[op.param_name] += shift
+                        copied_values[temp_name] += shift
+                        op.param_name = original_name
 
                     grad = (
                         spectral_gap

--- a/pyqtorch/gpsr.py
+++ b/pyqtorch/gpsr.py
@@ -120,6 +120,8 @@ class PSRExpectation(Function):
                         f_min = pyq.expectation(
                             ctx.circuit, ctx.state, copied_values, ctx.observable
                         )
+                        # reset values
+                        copied_values[op.param_name] += shift
 
                     grad = (
                         spectral_gap

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -317,10 +317,9 @@ def test_sample_run() -> None:
     assert "1100" in samples[0]
 
 
-# TODO delete this test when first one up is
 @pytest.mark.parametrize("n_qubits", [3, 4, 5])
 @pytest.mark.parametrize("same_angle", [True, False])
-def test_all_diff(n_qubits: int, same_angle: bool) -> None:
+def test_all_diff_singlegap(n_qubits: int, same_angle: bool) -> None:
     name_angle_1, name_angle_2 = "theta_0", "theta_1"
     if same_angle:
         name_angle_2 = name_angle_1

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -324,10 +324,11 @@ def test_all_diff_singlegap(n_qubits: int, same_angle: bool) -> None:
     if same_angle:
         name_angle_2 = name_angle_1
 
-    rx = pyq.RX(0, param_name=name_angle_1)
-    rz = pyq.RZ(2, param_name=name_angle_2)
+    ops_rx = pyq.Sequence([pyq.RX(i, param_name=name_angle_1) for i in range(n_qubits)])
+    ops_rz = pyq.Sequence([pyq.RZ(i, param_name=name_angle_2) for i in range(n_qubits)])
     cnot = pyq.CNOT(1, 2)
-    ops = [rx, rz, cnot]
+    ops = [ops_rx, ops_rz, cnot]
+
     circ = pyq.QuantumCircuit(n_qubits, ops)
     obs = pyq.QuantumCircuit(n_qubits, [pyq.Z(0)])
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -333,15 +333,17 @@ def test_all_diff(n_qubits: int, same_angle: bool) -> None:
     obs = pyq.QuantumCircuit(n_qubits, [pyq.Z(0)])
 
     theta_0_value = torch.pi / 2
-    theta_1_value = torch.pi
 
     state = pyq.zero_state(n_qubits)
 
     theta_0 = torch.tensor([theta_0_value], requires_grad=True)
 
-    theta_1 = torch.tensor([theta_1_value], requires_grad=True)
-
-    values = {name_angle_1: theta_0, name_angle_2: theta_1}
+    if same_angle:
+        values = {name_angle_1: theta_0}
+    else:
+        theta_1_value = torch.pi
+        theta_1 = torch.tensor([theta_1_value], requires_grad=True)
+        values = {name_angle_1: theta_0, name_angle_2: theta_1}
 
     exp_ad = expectation(circ, state, values, obs, DiffMode.AD)
     exp_adjoint = expectation(circ, state, values, obs, DiffMode.ADJOINT)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -327,14 +327,6 @@ def test_all_diff(n_qubits: int, same_angle: bool) -> None:
 
     rx = pyq.RX(0, param_name=name_angle_1)
     rz = pyq.RZ(2, param_name=name_angle_2)
-@pytest.mark.parametrize("same_angle", [True, False])
-def test_all_diff(n_qubits: int, same_angle: bool) -> None:
-    name_angle_1, name_angle_2 = "theta_0", "theta_1"
-    if same_angle:
-        name_angle_2 = name_angle_1
-
-    rx = pyq.RX(0, param_name=name_angle_1)
-    rz = pyq.RZ(2, param_name=name_angle_2)
     cnot = pyq.CNOT(1, 2)
     ops = [rx, rz, cnot]
     circ = pyq.QuantumCircuit(n_qubits, ops)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -319,9 +319,14 @@ def test_sample_run() -> None:
 
 # TODO delete this test when first one up is
 @pytest.mark.parametrize("n_qubits", [3, 4, 5])
-def test_all_diff(n_qubits: int) -> None:
-    rx = pyq.RX(0, param_name="theta_0")
-    rz = pyq.RZ(2, param_name="theta_1")
+@pytest.mark.parametrize("same_angle", [True, False])
+def test_all_diff(n_qubits: int, same_angle: bool) -> None:
+    name_angle_1, name_angle_2 = "theta_0", "theta_1"
+    if same_angle:
+        name_angle_2 = name_angle_1
+
+    rx = pyq.RX(0, param_name=name_angle_1)
+    rz = pyq.RZ(2, param_name=name_angle_2)
     cnot = pyq.CNOT(1, 2)
     ops = [rx, rz, cnot]
     circ = pyq.QuantumCircuit(n_qubits, ops)
@@ -336,7 +341,7 @@ def test_all_diff(n_qubits: int) -> None:
 
     theta_1 = torch.tensor([theta_1_value], requires_grad=True)
 
-    values = {"theta_0": theta_0, "theta_1": theta_1}
+    values = {name_angle_1: theta_0, name_angle_2: theta_1}
 
     exp_ad = expectation(circ, state, values, obs, DiffMode.AD)
     exp_adjoint = expectation(circ, state, values, obs, DiffMode.ADJOINT)


### PR DESCRIPTION
Handles #217 by only doing PSR on the current operation in loop to handle repeated param_name.