### PR TITLE
[Bug, Refactor] Modify tensor method

### DIFF
--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -18,7 +18,7 @@ from pyqtorch.apply import apply_operator
 from pyqtorch.matrices import IMAT, add_batch_dim
 from pyqtorch.parametric import RX, RY, Parametric
 from pyqtorch.primitive import CNOT, Primitive
-from pyqtorch.utils import State, product_state, zero_state
+from pyqtorch.utils import product_state, zero_state
 
 logger = getLogger(__name__)
 
@@ -98,8 +98,8 @@ class Sequence(Module):
         return hash(reduce(add, (hash(op) for op in self.operations)))
 
     def forward(
-        self, state: State, values: dict[str, Tensor] | ParameterDict = {}
-    ) -> State:
+        self, state: Tensor, values: dict[str, Tensor] | ParameterDict = {}
+    ) -> Tensor:
         for op in self.operations:
             state = op(state, values)
         return state
@@ -158,9 +158,9 @@ class QuantumCircuit(Sequence):
 
     def run(
         self,
-        state: State = None,
+        state: Tensor = None,
         values: dict[str, Tensor] | ParameterDict = {},
-    ) -> State:
+    ) -> Tensor:
         if state is None:
             state = self.init_state()
         elif isinstance(state, str):

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -13,7 +13,6 @@ from pyqtorch.matrices import (
     _unitary,
 )
 from pyqtorch.primitive import Primitive
-from pyqtorch.utils import Operator
 
 
 class Parametric(Primitive):
@@ -121,7 +120,7 @@ class Parametric(Primitive):
         """
         return values.unsqueeze(0) if len(values.size()) == 0 else values
 
-    def unitary(self, values: dict[str, Tensor] | Tensor = dict()) -> Operator:
+    def unitary(self, values: dict[str, Tensor] | Tensor = dict()) -> Tensor:
         """
         Get the corresponding unitary.
 
@@ -135,7 +134,7 @@ class Parametric(Primitive):
         batch_size = len(thetas)
         return _unitary(thetas, self.pauli, self.identity, batch_size)
 
-    def jacobian(self, values: dict[str, Tensor] | Tensor = dict()) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] | Tensor = dict()) -> Tensor:
         """
         Get the corresponding unitary of the jacobian.
 
@@ -257,7 +256,7 @@ class PHASE(Parametric):
         """
         super().__init__("I", target, param_name)
 
-    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary.
 
@@ -273,7 +272,7 @@ class PHASE(Parametric):
         batch_mat[1, 1, :] = torch.exp(1.0j * thetas).unsqueeze(0).unsqueeze(1)
         return batch_mat
 
-    def jacobian(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary of the jacobian.
 
@@ -335,7 +334,7 @@ class ControlledRotationGate(Parametric):
             f"control: {self.control}, target:{(self.target,)}, param:{self.param_name}"
         )
 
-    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary.
 
@@ -350,7 +349,7 @@ class ControlledRotationGate(Parametric):
         mat = _unitary(thetas, self.pauli, self.identity, batch_size)
         return _controlled(mat, batch_size, len(self.control))
 
-    def jacobian(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary of the jacobian.
 
@@ -460,7 +459,7 @@ class CPHASE(ControlledRotationGate):
         """
         super().__init__("I", control, target, param_name)
 
-    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary.
 
@@ -476,7 +475,7 @@ class CPHASE(ControlledRotationGate):
         mat[1, 1, :] = torch.exp(1.0j * thetas).unsqueeze(0).unsqueeze(1)
         return _controlled(mat, batch_size, len(self.control))
 
-    def jacobian(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary of the jacobian.
 
@@ -563,7 +562,7 @@ class U(Parametric):
             "d", torch.tensor([[0, 0], [0, 1]], dtype=DEFAULT_MATRIX_DTYPE).unsqueeze(2)
         )
 
-    def unitary(self, values: dict[str, Tensor] = dict()) -> Operator:
+    def unitary(self, values: dict[str, Tensor] = dict()) -> Tensor:
         """
         Get the corresponding unitary.
 
@@ -592,7 +591,7 @@ class U(Parametric):
         d = self.d.repeat(1, 1, batch_size) * cos_t * torch.conj(t_plus)
         return a - b + c + d
 
-    def jacobian(self, values: dict[str, Tensor] = {}) -> Operator:
+    def jacobian(self, values: dict[str, Tensor] = {}) -> Tensor:
         """
         Get the corresponding unitary of the jacobian.
 
@@ -620,7 +619,7 @@ class U(Parametric):
             RZ(self.qubit_support[0], self.omega),
         ]
 
-    def jacobian_decomposed(self, values: dict[str, Tensor] = dict()) -> list[Operator]:
+    def jacobian_decomposed(self, values: dict[str, Tensor] = dict()) -> list[Tensor]:
         """
         Get the corresponding unitary decomposition of the jacobian.
 

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -296,40 +296,6 @@ def operator_kron(op1: Tensor, op2: Tensor) -> Tensor:
     )
 
 
-def promote_operator(operator: Tensor, target: int, n_qubits: int) -> Tensor:
-    from pyqtorch.primitive import I
-
-    """
-    Promotes `operator` to the size of the circuit (number of qubits and batch).
-    Targeting the first qubit implies target = 0, so target > n_qubits - 1.
-
-    Arguments:
-        operator: The operator tensor to be promoted.
-        target: The index of the target qubit to which the operator is applied.
-            Targeting the first qubit implies target = 0, so target > n_qubits - 1.
-        n_qubits: Number of qubits in the circuit.
-
-    Returns:
-        Tensor: The promoted operator tensor.
-
-    Raises:
-        ValueError: If `target` is outside the valid range of qubits.
-    """
-    if target > n_qubits - 1:
-        raise ValueError(
-            "The target must be a valid qubit index within the circuit's range."
-        )
-    qubits = torch.arange(0, n_qubits)
-    qubits = qubits[qubits != target]
-    for qubit in qubits:
-        operator = torch.where(
-            target > qubit,
-            operator_kron(I(target).unitary(), operator),
-            operator_kron(operator, I(target).unitary()),
-        )
-    return operator
-
-
 def random_dm_promotion(
     target: int, dm_input: DensityMatrix, n_qubits: int
 ) -> DensityMatrix:

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -35,7 +35,6 @@ from pyqtorch.utils import (
     density_mat,
     operator_kron,
     product_state,
-    promote_operator,
     random_state,
 )
 
@@ -421,15 +420,7 @@ def test_dm(n_qubits: int, batch_size: int) -> None:
     assert torch.allclose(dm, dm_proj)
 
 
-def test_promote(random_gate: Primitive, n_qubits: int, target: int) -> None:
-    op_prom = promote_operator(random_gate.unitary(), target, n_qubits)
-    assert op_prom.size() == torch.Size([2**n_qubits, 2**n_qubits, 1])
-    assert torch.allclose(
-        operator_product(op_prom, _dagger(op_prom), target),
-        torch.eye(2**n_qubits, dtype=torch.cdouble).unsqueeze(2),
-    )
-
-
+# TODO: Modify this test as promote_operator has been erased.
 def test_operator_product(random_gate: Primitive, n_qubits: int, target: int) -> None:
     op = random_gate
     batch_size_1 = torch.randint(low=1, high=5, size=(1,)).item()

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -10,7 +10,7 @@ from conftest import _calc_mat_vec_wavefunction
 from torch import Tensor
 
 import pyqtorch as pyq
-from pyqtorch.apply import apply_operator, operator_product
+from pyqtorch.apply import apply_operator
 from pyqtorch.matrices import (
     DEFAULT_MATRIX_DTYPE,
     HMAT,
@@ -18,7 +18,6 @@ from pyqtorch.matrices import (
     XMAT,
     YMAT,
     ZMAT,
-    _dagger,
 )
 from pyqtorch.noise import (
     AmplitudeDamping,
@@ -420,25 +419,7 @@ def test_dm(n_qubits: int, batch_size: int) -> None:
     assert torch.allclose(dm, dm_proj)
 
 
-# TODO: Modify this test as promote_operator has been erased.
-def test_operator_product(random_gate: Primitive, n_qubits: int, target: int) -> None:
-    op = random_gate
-    batch_size_1 = torch.randint(low=1, high=5, size=(1,)).item()
-    batch_size_2 = torch.randint(low=1, high=5, size=(1,)).item()
-    max_batch = max(batch_size_2, batch_size_1)
-    op_prom = promote_operator(op.unitary(), target, n_qubits).repeat(
-        1, 1, batch_size_1
-    )
-    op_mul = operator_product(
-        op.unitary().repeat(1, 1, batch_size_2), _dagger(op_prom), target
-    )
-    assert op_mul.size() == torch.Size([2**n_qubits, 2**n_qubits, max_batch])
-    assert torch.allclose(
-        op_mul,
-        torch.eye(2**n_qubits, dtype=torch.cdouble)
-        .unsqueeze(2)
-        .repeat(1, 1, max_batch),
-    )
+# TODO: Modify test_operator_product as promote_operator has been erased.
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This pull request includes the following modifications :

**1. Bug Fix:**
- [x] The `tensor` method has been modified to correct the bug mentioned in issue #210  
- [x] It is now possible to call `tensor` for control gates, as well as for the special definition of `SWAP` and `CSWAP` gates, following the logic of the `BlockToTensor` method from qadence.

**2.Modification of the tensor Method for `operator_product`:**

- [x] Remove the `promote_operator` method because the `tensor` method now automatically handles the promotion by accepting the `n_qubits` parameter as needed. 
For example, if a gate is defined on 2 qubits (control and target) and it needs to be defined for a 4-qubit system, setting `n_qubits` to 4 is now sufficient.
- [x] Consequently, the `operator_product` function has been modified to no longer depend on `promote_operator` and we remove the `target` attribut. It now assumes that it receives tensors with the appropriate size, eliminating the need for further modifications #221.

**3.Modifications link to the forward passes of digital gates:**
- [x] Create the `apply_density_mat` to directly compute $O \rho O^{\dagger}$
- [x] Modify the `Noise` and `Primitive` `forward` methods according all the modification bellow. 

**4.Add tests:**
