### PR TITLE
[Bug] Fix check support PSR

### DIFF
--- a/pyqtorch/gpsr.py
+++ b/pyqtorch/gpsr.py
@@ -226,9 +226,10 @@ def check_support_psr(circuit: QuantumCircuit):
             for subop in op.flatten():
                 if isinstance(subop, Parametric):
                     if isinstance(subop.param_name, str):
+                        if len(subop.spectral_gap) > 1:
+                            raise NotImplementedError("Multi-gap is not yet supported.")
                         param_names.append(subop.param_name)
-                if len(subop.spectral_gap) > 1:
-                    raise NotImplementedError("Multi-gap is not yet supported.")
+
         elif isinstance(op, Parametric):
             if len(op.spectral_gap) > 1:
                 raise NotImplementedError("Multi-gap is not yet supported.")

--- a/tests/test_differentiation.py
+++ b/tests/test_differentiation.py
@@ -266,7 +266,7 @@ def test_all_diff_singlegap(
             assert torch.allclose(gradgrad_ad[j], gradgrad_gpsr[j], atol=GRADCHECK_ATOL)
 
 
-@pytest.mark.parametrize("gate_type", ["scale", "hamevo", ""])
+@pytest.mark.parametrize("gate_type", ["scale", "hamevo", "same", ""])
 def test_compatibility_gpsr(gate_type: str) -> None:
 
     pname = "theta_0"
@@ -277,18 +277,30 @@ def test_compatibility_gpsr(gate_type: str) -> None:
     elif gate_type == "hamevo":
         hamevo = pyq.HamiltonianEvolution(pyq.Sequence([pyq.X(0)]), pname, (0,))
         ops = [hamevo]
-    else:
+    elif gate_type == "same":
         ops = [pyq.RY(0, pname), pyq.RZ(0, pname)]
+    else:
+        # check that CNOT is not tested on spectral gap call
+        ops = [pyq.RY(0, pname), pyq.CNOT(0, 1)]
 
-    circ = pyq.QuantumCircuit(1, ops)
-    obs = pyq.Observable(1, [pyq.Z(0)])
-    state = pyq.zero_state(1)
+    circ = pyq.QuantumCircuit(2, ops)
+    obs = pyq.Observable(2, [pyq.Z(0)])
+    state = pyq.zero_state(2)
 
     param_value = torch.pi / 2
     values = {"theta_0": torch.tensor([param_value], requires_grad=True)}
-    with pytest.raises(ValueError):
+
+    if gate_type != "":
+        with pytest.raises(ValueError):
+            exp_gpsr = expectation(circ, state, values, obs, DiffMode.GPSR)
+
+            grad_gpsr = torch.autograd.grad(
+                exp_gpsr, tuple(values.values()), torch.ones_like(exp_gpsr)
+            )
+    else:
         exp_gpsr = expectation(circ, state, values, obs, DiffMode.GPSR)
 
         grad_gpsr = torch.autograd.grad(
             exp_gpsr, tuple(values.values()), torch.ones_like(exp_gpsr)
         )
+        assert len(grad_gpsr) > 0


### PR DESCRIPTION
Fix the `if` order in `check_support_psr` to avoid checking the spectral gap for other unconcerned gates, which raises an error. 