### PR TITLE
[Refact] Consistent base classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 requires-python = ">=3.8,<3.13"
 license = {text = "Apache 2.0"}
-version = "1.3.2"
+version = "1.4.0"
 classifiers=[
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",

--- a/pyqtorch/adjoint.py
+++ b/pyqtorch/adjoint.py
@@ -76,7 +76,7 @@ class AdjointExpectation(Function):
         values = param_dict(ctx.param_names, param_values)
         grads_dict = {k: None for k in values.keys()}
         for op in ctx.circuit.flatten()[::-1]:
-            if isinstance(op, Primitive):
+            if isinstance(op, (Primitive, Parametric)):
                 ctx.out_state = apply_operator(
                     ctx.out_state, op.dagger(values, ctx.embedding), op.qubit_support
                 )

--- a/pyqtorch/analog.py
+++ b/pyqtorch/analog.py
@@ -121,30 +121,24 @@ class Scale(Sequence):
         values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
-        diagonal: bool = False,
     ) -> Operator:
         """
         Get the corresponding unitary over n_qubits.
 
         Arguments:
             values: Parameter value.
+            embedding: An optional embedding.
             full_support: Can be higher than the number of qubit support.
-            diagonal: Whether the operation is diagonal.
-
 
         Returns:
             The unitary representation.
-        Raises:
-            NotImplementedError for the diagonal case.
         """
         scale = (
             values[self.param_name]
             if isinstance(self.param_name, str)
             else self.param_name
         )
-        return scale * self.operations[0].tensor(
-            values, embedding, full_support, diagonal
-        )
+        return scale * self.operations[0].tensor(values, embedding, full_support)
 
     def flatten(self) -> list[Scale]:
         """This method should only be called in the AdjointExpectation,
@@ -204,7 +198,6 @@ class Add(Sequence):
         values: dict = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
-        diagonal: bool = False,
     ) -> Tensor:
         """
         Get the corresponding sum of unitaries over n_qubits.
@@ -212,13 +205,10 @@ class Add(Sequence):
         Arguments:
             values: Parameter value.
             Can be higher than the number of qubit support.
-            diagonal: Whether the operation is diagonal.
 
 
         Returns:
             The unitary representation.
-        Raises:
-            NotImplementedError for the diagonal case.
         """
         if full_support is None:
             full_support = self.qubit_support
@@ -232,10 +222,7 @@ class Add(Sequence):
         )
         return reduce(
             add,
-            (
-                op.tensor(values, embedding, full_support, diagonal)
-                for op in self.operations
-            ),
+            (op.tensor(values, embedding, full_support) for op in self.operations),
             mat,
         )
 
@@ -516,7 +503,6 @@ class HamiltonianEvolution(Sequence):
         values: dict = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
-        diagonal: bool = False,
     ) -> Operator:
         """Get the corresponding unitary over n_qubits.
 
@@ -525,16 +511,10 @@ class HamiltonianEvolution(Sequence):
         Arguments:
             values: Parameter value.
             Can be higher than the number of qubit support.
-            diagonal: Whether the operation is diagonal.
-
 
         Returns:
             The unitary representation.
-        Raises:
-            NotImplementedError for the diagonal case.
         """
-        if diagonal:
-            raise NotImplementedError
         values_cache_key = str(OrderedDict(values))
         if self.cache_length > 0 and values_cache_key in self._cache_hamiltonian_evo:
             evolved_op = self._cache_hamiltonian_evo[values_cache_key]

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -403,7 +403,7 @@ class Merge(Sequence):
         return reduce(
             lambda u0, u1: einsum("ijb,jkb->ikb", u0, u1),
             (
-                add_batch_dim(op.unitary(values, embedding), batch_size)
+                add_batch_dim(op.tensor(values, embedding), batch_size)
                 for op in reversed(self.operations)
             ),
         )

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -107,7 +107,7 @@ class Sequence(Module):
     def forward(
         self,
         state: State,
-        values: dict[str, Tensor] | ParameterDict = {},
+        values: dict[str, Tensor] | ParameterDict = dict(),
         embedding: Embedding | None = None,
     ) -> State:
         for op in self.operations:
@@ -184,7 +184,7 @@ class QuantumCircuit(Sequence):
     def run(
         self,
         state: State = None,
-        values: dict[str, Tensor] | ParameterDict = {},
+        values: dict[str, Tensor] | ParameterDict = dict(),
         embedding: Embedding | None = None,
     ) -> State:
         if state is None:
@@ -254,7 +254,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
     def forward(
         self,
         state: State,
-        values: dict[str, Tensor] | ParameterDict = {},
+        values: dict[str, Tensor] | ParameterDict = dict(),
         embedding: Embedding | None = None,
     ) -> State:
         if self.training:
@@ -265,7 +265,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
         return state
 
     def rotational_dropout(
-        self, state: State = None, values: dict[str, Tensor] | ParameterDict = {}
+        self, state: State = None, values: dict[str, Tensor] | ParameterDict = dict()
     ) -> State:
         """Randomly drops entangling rotational gates.
 
@@ -287,7 +287,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
         return state
 
     def entangling_dropout(
-        self, state: State = None, values: dict[str, Tensor] | ParameterDict = {}
+        self, state: State = None, values: dict[str, Tensor] | ParameterDict = dict()
     ) -> State:
         """Randomly drops entangling gates.
 
@@ -308,7 +308,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
         return state
 
     def canonical_fwd_dropout(
-        self, state: State = None, values: dict[str, Tensor] | ParameterDict = {}
+        self, state: State = None, values: dict[str, Tensor] | ParameterDict = dict()
     ) -> State:
         """Randomly drops rotational gates and next immediate entangling
         gates whose target bit is located on dropped rotational gates.
@@ -371,7 +371,7 @@ class Merge(Sequence):
     def forward(
         self,
         state: Tensor,
-        values: dict[str, Tensor] | None = None,
+        values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
     ) -> Tensor:
         batch_size = state.shape[-1]
@@ -389,21 +389,22 @@ class Merge(Sequence):
             )
         return apply_operator(
             state,
-            self.unitary(values, embedding, batch_size),
+            add_batch_dim(self.tensor(values, embedding), batch_size),
             self.qubits,
         )
 
-    def unitary(
+    def tensor(
         self,
-        values: dict[str, Tensor] | None,
-        embedding: Embedding | None,
-        batch_size: int,
+        values: dict[str, Tensor] = dict(),
+        embedding: Embedding | None = None,
+        full_support: tuple[int, ...] | None = None,
+        diagonal: bool = False,
     ) -> Tensor:
         # We reverse the list of tensors here since matmul is not commutative.
         return reduce(
             lambda u0, u1: einsum("ijb,jkb->ikb", u0, u1),
             (
-                add_batch_dim(op.tensor(values, embedding), batch_size)
+                op.tensor(values, embedding, full_support, diagonal)
                 for op in reversed(self.operations)
             ),
         )

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -327,7 +327,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
                 and (values[op.param_name].requires_grad)
                 and not (int(1 - bernoulli(tensor(self.dropout_prob))))
             ):
-                entanglers_to_drop[op.target] = 1
+                entanglers_to_drop[op.qubit_support[-1]] = 1
             else:
                 if not hasattr(op, "param_name") and (
                     entanglers_to_drop[op.control[0]] == 1

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -324,7 +324,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
                 and (values[op.param_name].requires_grad)
                 and not (int(1 - bernoulli(tensor(self.dropout_prob))))
             ):
-                entanglers_to_drop[op.qubit_support[-1]] = 1
+                entanglers_to_drop[op.target] = 1
             else:
                 if not hasattr(op, "param_name") and (
                     entanglers_to_drop[op.control[0]] == 1

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -143,10 +143,7 @@ class Sequence(Module):
         values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
-        diagonal: bool = False,
     ) -> Tensor:
-        if diagonal:
-            raise NotImplementedError
         if full_support is None:
             full_support = self.qubit_support
         elif not set(self.qubit_support).issubset(set(full_support)):
@@ -398,13 +395,12 @@ class Merge(Sequence):
         values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
-        diagonal: bool = False,
     ) -> Tensor:
         # We reverse the list of tensors here since matmul is not commutative.
         return reduce(
             lambda u0, u1: einsum("ijb,jkb->ikb", u0, u1),
             (
-                op.tensor(values, embedding, full_support, diagonal)
+                op.tensor(values, embedding, full_support)
                 for op in reversed(self.operations)
             ),
         )

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -1,0 +1,121 @@
+from typing import Any
+from math import log2
+
+from functools import cached_property
+
+
+import torch
+from logging import getLogger
+from torch import Tensor
+import numpy as np
+
+from pyqtorch.embed import Embedding
+from pyqtorch.utils import DensityMatrix, expand_operator, permute_basis, product_state
+
+
+logger = getLogger(__name__)
+
+
+def forward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    torch.cuda.nvtx.range_pop()
+
+
+def pre_forward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    torch.cuda.nvtx.range_push("QuantumOperation.forward")
+
+
+def backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    torch.cuda.nvtx.range_pop()
+
+
+def pre_backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+    torch.cuda.nvtx.range_push("QuantumOperation.backward")
+
+class QuantumOperation(torch.nn.Module):
+    """Basic QuantumOperation class storing a tensor operation which can represent either 
+        a quantum operator or a generator inferring the QuantumOperation.
+    
+    Attributes:
+        operation: Tensor used to infer the QuantumOperation
+            directly or indirectly.
+        qubit_support: List of qubits the QuantumOperation acts on.
+        
+    """
+    def __init__(
+        self,
+        operation: Tensor,
+        qubit_support: int | tuple[int, ...],
+    ) -> None:
+
+        qubit_support = (
+            (qubit_support,) if isinstance(qubit_support, int) else qubit_support
+        )
+        if isinstance(qubit_support, np.integer):
+            qubit_support = (qubit_support.item(),)
+        
+        if len(qubit_support) != int(log2(operation.shape[0])):
+            raise ValueError("The operation shape should match the legth of the qubit_support.")
+        
+        self._qubit_support = qubit_support
+        self.qubit_support = tuple(sorted(qubit_support))
+
+        self.operation = operation
+        self.register_buffer("operation", operation)
+        self._device = self.operation.device
+        self._dtype = self.operation.dtype
+    
+    def to(self, *args: Any, **kwargs: Any) -> QuantumOperation:
+        super().to(*args, **kwargs)
+        self._device = self.operation.device
+        self._dtype = self.operation.dtype
+        return self
+    
+    def __hash__(self) -> int:
+        return hash(self.qubit_support)
+
+    def extra_repr(self) -> str:
+        return f"{self.qubit_support}"
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+    
+    @cached_property
+    def eigenvals_generator(self) -> Tensor:
+        """Get eigenvalues of the underlying operation.
+
+        Arguments:
+            values: Parameter values.
+
+        Returns:
+            Eigenvalues of the operation.
+        """
+        return torch.linalg.eigvalsh(self.operation).reshape(-1, 1)
+    
+    @cached_property
+    def spectral_gap(self) -> Tensor:
+        """Difference between the moduli of the two largest eigenvalues of the generator.
+
+        Returns:
+            Tensor: Spectral gap value.
+        """
+        spectrum = self.eigenvals_generator
+        spectral_gap = torch.unique(torch.abs(torch.tril(spectrum - spectrum.T)))
+        return spectral_gap[spectral_gap.nonzero()]
+    
+    def tensor(
+        self,
+        values: dict[str, Tensor] = {},
+        embedding: Embedding | None = None,
+        full_support: tuple[int, ...] | None = None,
+        diagonal: bool = False,
+    ) -> Tensor:
+        return self.operation
+    
+    def forward(self, state: Tensor):
+        raise NotImplementedError
+        

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from functools import cached_property
 from logging import getLogger
-from math import log2
 from typing import Any
 
 import torch
@@ -60,11 +59,6 @@ class QuantumOperation(torch.nn.Module):
         """
         super().__init__()
         qubit_support = get_tuple_qubit_support(qubit_support)
-
-        if len(qubit_support) != int(log2(operation.shape[0])):
-            raise ValueError(
-                "The operation shape should match the legth of the qubit_support."
-            )
 
         self._qubit_support = qubit_support
         self.qubit_support = tuple(sorted(qubit_support))

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -173,8 +173,8 @@ class QuantumOperation(torch.nn.Module):
             return DensityMatrix(
                 operator_product(
                     self.unitary(values, embedding),
-                    operator_product(state, self.dagger(values, embedding), self.qubit_support),  # type: ignore [arg-type]
-                    self.qubit_support,  # type: ignore [arg-type]
+                    operator_product(state, self.dagger(values, embedding), self.qubit_support[-1]),  # type: ignore [arg-type]
+                    self.qubit_support[-1],  # type: ignore [arg-type]
                 )
             )
         else:

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -47,7 +47,7 @@ class QuantumOperation(torch.nn.Module):
     Attributes:
         operation (Tensor): Tensor used to infer the QuantumOperation
             directly or indirectly.
-        qubit_support (int | tuple[int, ...]): List of qubits
+        qubit_support (int | tuple[int, ...]): Tuple of qubits
             the QuantumOperation acts on.
         operator_function (Callable | None, optional): Function to generate the base operator
             from operation. If None, we consider returning operation itself.

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from functools import cached_property
 from logging import getLogger
 from math import log2
@@ -72,6 +73,14 @@ class QuantumOperation(torch.nn.Module):
         self.register_buffer("operation", operation)
         self._device = self.operation.device
         self._dtype = self.operation.dtype
+
+        if logger.isEnabledFor(logging.DEBUG):
+            # When Debugging let's add logging and NVTX markers
+            # WARNING: incurs performance penalty
+            self.register_forward_hook(forward_hook, always_call=True)
+            self.register_full_backward_hook(backward_hook)
+            self.register_forward_pre_hook(pre_forward_hook)
+            self.register_full_backward_pre_hook(pre_backward_hook)
 
     def to(self, *args: Any, **kwargs: Any) -> QuantumOperation:
         super().to(*args, **kwargs)

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -39,7 +39,7 @@ def pre_backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
 
 
 class QuantumOperation(torch.nn.Module):
-    """Basic QuantumOperation class storing a tensor operation which can represent either
+    """Generic QuantumOperation class storing a tensor operation to represent either
         a quantum operator or a tensor generator inferring the QuantumOperation.
 
     Note that the methods below are meant

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -58,7 +58,7 @@ class QuantumOperation(torch.nn.Module):
         Raises:
             ValueError: _description_
         """
-
+        super().__init__()
         qubit_support = get_tuple_qubit_support(qubit_support)
 
         if len(qubit_support) != int(log2(operation.shape[0])):
@@ -69,7 +69,6 @@ class QuantumOperation(torch.nn.Module):
         self._qubit_support = qubit_support
         self.qubit_support = tuple(sorted(qubit_support))
 
-        self.operation = operation
         self.register_buffer("operation", operation)
         self._device = self.operation.device
         self._dtype = self.operation.dtype

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -1,17 +1,15 @@
-from typing import Any
-from math import log2
+from __future__ import annotations
 
 from functools import cached_property
-
-
-import torch
 from logging import getLogger
-from torch import Tensor
+from math import log2
+from typing import Any
+
 import numpy as np
+import torch
+from torch import Tensor
 
 from pyqtorch.embed import Embedding
-from pyqtorch.utils import DensityMatrix, expand_operator, permute_basis, product_state
-
 
 logger = getLogger(__name__)
 
@@ -31,31 +29,46 @@ def backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
 def pre_backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
     torch.cuda.nvtx.range_push("QuantumOperation.backward")
 
+
 class QuantumOperation(torch.nn.Module):
-    """Basic QuantumOperation class storing a tensor operation which can represent either 
+    """Basic QuantumOperation class storing a tensor operation which can represent either
         a quantum operator or a generator inferring the QuantumOperation.
-    
+
     Attributes:
-        operation: Tensor used to infer the QuantumOperation
+        operation (Tensor): Tensor used to infer the QuantumOperation
             directly or indirectly.
-        qubit_support: List of qubits the QuantumOperation acts on.
-        
+        qubit_support (int | tuple[int, ...]): List of qubits
+            the QuantumOperation acts on.
+
     """
+
     def __init__(
         self,
         operation: Tensor,
         qubit_support: int | tuple[int, ...],
     ) -> None:
+        """Initializes QuantumOperation
+
+        Args:
+            operation (Tensor): Tensor used to infer the QuantumOperation.
+            qubit_support (int | tuple[int, ...]): List of qubits
+                the QuantumOperation acts on.
+
+        Raises:
+            ValueError: _description_
+        """
 
         qubit_support = (
             (qubit_support,) if isinstance(qubit_support, int) else qubit_support
         )
         if isinstance(qubit_support, np.integer):
             qubit_support = (qubit_support.item(),)
-        
+
         if len(qubit_support) != int(log2(operation.shape[0])):
-            raise ValueError("The operation shape should match the legth of the qubit_support.")
-        
+            raise ValueError(
+                "The operation shape should match the legth of the qubit_support."
+            )
+
         self._qubit_support = qubit_support
         self.qubit_support = tuple(sorted(qubit_support))
 
@@ -63,13 +76,13 @@ class QuantumOperation(torch.nn.Module):
         self.register_buffer("operation", operation)
         self._device = self.operation.device
         self._dtype = self.operation.dtype
-    
+
     def to(self, *args: Any, **kwargs: Any) -> QuantumOperation:
         super().to(*args, **kwargs)
         self._device = self.operation.device
         self._dtype = self.operation.dtype
         return self
-    
+
     def __hash__(self) -> int:
         return hash(self.qubit_support)
 
@@ -83,7 +96,7 @@ class QuantumOperation(torch.nn.Module):
     @property
     def dtype(self) -> torch.dtype:
         return self._dtype
-    
+
     @cached_property
     def eigenvals_generator(self) -> Tensor:
         """Get eigenvalues of the underlying operation.
@@ -95,7 +108,7 @@ class QuantumOperation(torch.nn.Module):
             Eigenvalues of the operation.
         """
         return torch.linalg.eigvalsh(self.operation).reshape(-1, 1)
-    
+
     @cached_property
     def spectral_gap(self) -> Tensor:
         """Difference between the moduli of the two largest eigenvalues of the generator.
@@ -106,7 +119,7 @@ class QuantumOperation(torch.nn.Module):
         spectrum = self.eigenvals_generator
         spectral_gap = torch.unique(torch.abs(torch.tril(spectrum - spectrum.T)))
         return spectral_gap[spectral_gap.nonzero()]
-    
+
     def tensor(
         self,
         values: dict[str, Tensor] = {},
@@ -115,7 +128,6 @@ class QuantumOperation(torch.nn.Module):
         diagonal: bool = False,
     ) -> Tensor:
         return self.operation
-    
+
     def forward(self, state: Tensor):
         raise NotImplementedError
-        

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -40,7 +40,7 @@ def pre_backward_hook(*args, **kwargs) -> None:  # type: ignore[no-untyped-def]
 
 class QuantumOperation(torch.nn.Module):
     """Basic QuantumOperation class storing a tensor operation which can represent either
-        a quantum operator or a generator inferring the QuantumOperation.
+        a quantum operator or a tensor generator inferring the QuantumOperation.
 
     Note that the methods below are meant
 

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -14,8 +14,8 @@ from pyqtorch.matrices import _dagger
 from pyqtorch.utils import (
     DensityMatrix,
     expand_operator,
-    get_tuple_qubit_support,
     permute_basis,
+    qubit_support_as_tuple,
 )
 
 logger = getLogger(__name__)
@@ -65,10 +65,9 @@ class QuantumOperation(torch.nn.Module):
             ValueError: _description_
         """
         super().__init__()
-        qubit_support = get_tuple_qubit_support(qubit_support)
+        qubit_support = qubit_support_as_tuple(qubit_support)
 
         self._qubit_support = qubit_support
-        self.qubit_support = tuple(sorted(qubit_support))
 
         self.register_buffer("operation", operation)
         self._device = self.operation.device
@@ -87,6 +86,10 @@ class QuantumOperation(torch.nn.Module):
         self._device = self.operation.device
         self._dtype = self.operation.dtype
         return self
+
+    @cached_property
+    def qubit_support(self) -> tuple[int, ...]:
+        return tuple(sorted(self._qubit_support))
 
     def __hash__(self) -> int:
         return hash(self.qubit_support)

--- a/pyqtorch/generic_quantum_ops.py
+++ b/pyqtorch/generic_quantum_ops.py
@@ -5,11 +5,11 @@ from logging import getLogger
 from math import log2
 from typing import Any
 
-import numpy as np
 import torch
 from torch import Tensor
 
 from pyqtorch.embed import Embedding
+from pyqtorch.utils import get_tuple_qubit_support
 
 logger = getLogger(__name__)
 
@@ -58,11 +58,7 @@ class QuantumOperation(torch.nn.Module):
             ValueError: _description_
         """
 
-        qubit_support = (
-            (qubit_support,) if isinstance(qubit_support, int) else qubit_support
-        )
-        if isinstance(qubit_support, np.integer):
-            qubit_support = (qubit_support.item(),)
+        qubit_support = get_tuple_qubit_support(qubit_support)
 
         if len(qubit_support) != int(log2(operation.shape[0])):
             raise ValueError(

--- a/pyqtorch/matrices.py
+++ b/pyqtorch/matrices.py
@@ -98,19 +98,19 @@ def _jacobian(
     return -1 / 2 * (sin_t * batch_imat + 1j * cos_t * batch_operation_mat)
 
 
-def _controlled(
-    unitary: torch.Tensor, batch_size: int, n_control_qubits: int = 1
+def controlled(
+    operation: torch.Tensor, batch_size: int, n_control_qubits: int = 1
 ) -> torch.Tensor:
     _controlled: torch.Tensor = (
         torch.eye(
-            2 ** (n_control_qubits + 1), dtype=unitary.dtype, device=unitary.device
+            2 ** (n_control_qubits + 1), dtype=operation.dtype, device=operation.device
         )
         .unsqueeze(2)
         .repeat(1, 1, batch_size)
     )
     _controlled[
         2 ** (n_control_qubits + 1) - 2 :, 2 ** (n_control_qubits + 1) - 2 :, :
-    ] = unitary
+    ] = operation
     return _controlled
 
 

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -10,8 +10,8 @@ from pyqtorch.embed import Embedding
 from pyqtorch.matrices import (
     DEFAULT_MATRIX_DTYPE,
     OPERATIONS_DICT,
-    _controlled,
     _jacobian,
+    controlled,
     parametric_unitary,
 )
 from pyqtorch.quantum_ops import QuantumOperation, Support
@@ -249,7 +249,7 @@ class ControlledParametric(Parametric):
         thetas = self.parse_values(values, embedding)
         batch_size = len(thetas)
         mat = parametric_unitary(thetas, self.operation, self.identity, batch_size)
-        mat = _controlled(mat, batch_size, len(self.control))
+        mat = controlled(mat, batch_size, len(self.control))
         return mat
 
     def jacobian(
@@ -715,7 +715,7 @@ class CPHASE(ControlledRotationGate):
         batch_size = len(thetas)
         mat = self.identity.unsqueeze(2).repeat(1, 1, batch_size)
         mat[1, 1, :] = torch.exp(1.0j * thetas).unsqueeze(0).unsqueeze(1)
-        return _controlled(mat, batch_size, len(self.control))
+        return controlled(mat, batch_size, len(self.control))
 
     def jacobian(
         self, values: dict[str, Tensor] = dict(), embedding: Embedding | None = None

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -342,16 +342,16 @@ class RX(Parametric):
 
     def __init__(
         self,
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes RX.
 
         Arguments:
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("X", qubit_support, param_name)
+        super().__init__("X", target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:
@@ -381,16 +381,16 @@ class RY(Parametric):
 
     def __init__(
         self,
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes RY.
 
         Arguments:
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("Y", qubit_support, param_name)
+        super().__init__("Y", target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:
@@ -420,16 +420,16 @@ class RZ(Parametric):
 
     def __init__(
         self,
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes RZ.
 
         Arguments:
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("Z", qubit_support, param_name)
+        super().__init__("Z", target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:
@@ -459,16 +459,16 @@ class PHASE(Parametric):
 
     def __init__(
         self,
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes PHASE.
 
         Arguments:
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("I", qubit_support, param_name)
+        super().__init__("I", target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:
@@ -780,10 +780,11 @@ class U(Parametric):
 
     n_params = 3
 
-    def __init__(self, qubit_support: int, phi: str, theta: str, omega: str):
+    def __init__(self, target: int, phi: str, theta: str, omega: str):
         """Initializes U gate.
 
         Arguments:
+            target: Target qubit.
             phi: Phi parameter.
             theta: Theta parameter.
             omega: Omega parameter.
@@ -791,7 +792,7 @@ class U(Parametric):
         self.phi = phi
         self.theta = theta
         self.omega = omega
-        super().__init__("X", qubit_support, param_name="")
+        super().__init__("X", target, param_name="")
 
         self.register_buffer(
             "a", torch.tensor([[1, 0], [0, 0]], dtype=DEFAULT_MATRIX_DTYPE).unsqueeze(2)
@@ -877,9 +878,9 @@ class U(Parametric):
             The digital decomposition.
         """
         return [
-            RZ(self.qubit_support[0], self.phi),
-            RY(self.qubit_support[0], self.theta),
-            RZ(self.qubit_support[0], self.omega),
+            RZ(self.target[0], self.phi),
+            RY(self.target[0], self.theta),
+            RZ(self.target[0], self.omega),
         ]
 
     def jacobian_decomposed(self, values: dict[str, Tensor] = dict()) -> list[Operator]:

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -7,7 +7,6 @@ import torch
 from torch import Tensor
 
 from pyqtorch.embed import Embedding
-from pyqtorch.generic_quantum_ops import QuantumOperation
 from pyqtorch.matrices import (
     DEFAULT_MATRIX_DTYPE,
     OPERATIONS_DICT,
@@ -15,6 +14,7 @@ from pyqtorch.matrices import (
     _jacobian,
     parametric_unitary,
 )
+from pyqtorch.quantum_ops import QuantumOperation
 from pyqtorch.utils import Operator, qubit_support_as_tuple
 
 pauli_singleq_eigenvalues = torch.tensor([[-1.0], [1.0]], dtype=torch.cdouble)

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -877,10 +877,11 @@ class U(Parametric):
         Returns:
             The digital decomposition.
         """
+        target = self.target[0]
         return [
-            RZ(self.target[0], self.phi),
-            RY(self.target[0], self.theta),
-            RZ(self.target[0], self.omega),
+            RZ(target, self.phi),
+            RY(target, self.theta),
+            RZ(target, self.omega),
         ]
 
     def jacobian_decomposed(self, values: dict[str, Tensor] = dict()) -> list[Operator]:

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -14,8 +14,8 @@ from pyqtorch.matrices import (
     _jacobian,
     parametric_unitary,
 )
-from pyqtorch.quantum_ops import QuantumOperation
-from pyqtorch.utils import Operator, qubit_support_as_tuple
+from pyqtorch.quantum_ops import QuantumOperation, Support
+from pyqtorch.utils import Operator
 
 pauli_singleq_eigenvalues = torch.tensor([[-1.0], [1.0]], dtype=torch.cdouble)
 
@@ -34,7 +34,7 @@ class Parametric(QuantumOperation):
     def __init__(
         self,
         generator: str | Tensor,
-        qubit_support: int | tuple[int, ...],
+        qubit_support: int | tuple[int, ...] | Support,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes Parametric.
@@ -219,9 +219,8 @@ class ControlledParametric(Parametric):
             qubit_targets: Target qubit(s).
             param_name: Name of parameters.
         """
-        self.control = qubit_support_as_tuple(control)
-        self.target = qubit_support_as_tuple(target)
-        super().__init__(operation, self.control + self.target, param_name)
+        support = Support(target, control)
+        super().__init__(operation, support, param_name)
 
     def extra_repr(self) -> str:
         """String representation of the operation.

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -15,7 +15,7 @@ from pyqtorch.matrices import (
     _jacobian,
     parametric_unitary,
 )
-from pyqtorch.utils import Operator, get_tuple_qubit_support, permute_basis
+from pyqtorch.utils import Operator, permute_basis, qubit_support_as_tuple
 
 pauli_singleq_eigenvalues = torch.tensor([[-1.0], [1.0]], dtype=torch.cdouble)
 
@@ -213,8 +213,8 @@ class ControlledParametric(Parametric):
             qubit_targets: Target qubit(s).
             param_name: Name of parameters.
         """
-        self.control = get_tuple_qubit_support(control)
-        self.target = get_tuple_qubit_support(target)
+        self.control = qubit_support_as_tuple(control)
+        self.target = qubit_support_as_tuple(target)
         super().__init__(operation, self.control + self.target, param_name)
 
     def extra_repr(self) -> str:

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -108,6 +108,9 @@ class Parametric(QuantumOperation):
         elif isinstance(param_name, (float, int, torch.Tensor)):
             self.parse_values = parse_constant
 
+        # Parametric is defined by generator operation and a function
+        # The function will use parsed parameter values
+        # to compute the unitary
         super().__init__(
             generator_operation,
             qubit_support,
@@ -149,7 +152,7 @@ class Parametric(QuantumOperation):
         embedding: Embedding | None = None,
     ) -> Operator:
         """
-        Get the corresponding unitary.
+        Get the corresponding unitary with parsed values.
 
         Arguments:
             values: A dict containing a Parameter name and value.
@@ -234,7 +237,8 @@ class ControlledParametric(Parametric):
         self, values: dict[str, Tensor] = dict(), embedding: Embedding | None = None
     ) -> Operator:
         """
-        Get the corresponding unitary.
+        Get the corresponding unitary with parsed values and kronned identities
+        for control.
 
         Arguments:
             values: A dict containing a Parameter name and value.
@@ -279,10 +283,6 @@ class ControlledParametric(Parametric):
 class ControlledRotationGate(ControlledParametric):
     """
     Primitives for controlled rotation operations.
-
-    Attributes:
-        control: Control qubit(s).
-        qubit_support: Qubits acted on.
     """
 
     n_params = 1

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -569,17 +569,17 @@ class CRY(ControlledRotationGate):
     def __init__(
         self,
         control: int | Tuple[int, ...],
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes controlled RY.
 
         Arguments:
             control: Control qubit(s).
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("Y", control, qubit_support, param_name)
+        super().__init__("Y", control, target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:
@@ -613,17 +613,17 @@ class CRZ(ControlledRotationGate):
     def __init__(
         self,
         control: int | Tuple[int, ...],
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes controlled RZ.
 
         Arguments:
             control: Control qubit(s).
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("Z", control, qubit_support, param_name)
+        super().__init__("Z", control, target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:
@@ -659,17 +659,17 @@ class CPHASE(ControlledRotationGate):
     def __init__(
         self,
         control: int | Tuple[int, ...],
-        qubit_support: int,
+        target: int,
         param_name: str | int | float | torch.Tensor = "",
     ):
         """Initializes controlled PHASE.
 
         Arguments:
             control: Control qubit(s).
-            qubit_support: Target qubit.
+            target: Target qubit.
             param_name: Name of parameters.
         """
-        super().__init__("I", control, qubit_support, param_name)
+        super().__init__("I", control, target, param_name)
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -239,7 +239,7 @@ class ControlledParametric(Parametric):
         """
         thetas = self.parse_values(values, embedding)
         batch_size = len(thetas)
-        mat = _unitary(thetas, self.pauli, self.identity, batch_size)
+        mat = _unitary(thetas, self.operation, self.identity, batch_size)
         return _controlled(mat, batch_size, len(self.control))
 
     def jacobian(
@@ -257,7 +257,7 @@ class ControlledParametric(Parametric):
         thetas = self.parse_values(values, embedding)
         batch_size = len(thetas)
         n_control = len(self.control)
-        jU = _jacobian(thetas, self.pauli, self.identity, batch_size)
+        jU = _jacobian(thetas, self.operation, self.identity, batch_size)
         n_dim = 2 ** (n_control + 1)
         jC = (
             torch.zeros((n_dim, n_dim), dtype=self.identity.dtype)

--- a/pyqtorch/parametric.py
+++ b/pyqtorch/parametric.py
@@ -242,8 +242,11 @@ class ControlledParametric(Parametric):
         """
         thetas = self.parse_values(values, embedding)
         batch_size = len(thetas)
-        mat = _unitary(thetas, self.operation, self.identity, batch_size)
-        return _controlled(mat, batch_size, len(self.control))
+        mat = parametric_unitary(thetas, self.operation, self.identity, batch_size)
+        mat = _controlled(mat, batch_size, len(self.control))
+        if self._qubit_support != self.qubit_support:
+            mat = permute_basis(mat, self._qubit_support)
+        return mat
 
     def jacobian(
         self, values: dict[str, Tensor] = dict(), embedding: Embedding | None = None

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
+from math import log2
 
 import torch
 from torch import Tensor
@@ -36,6 +37,10 @@ class Primitive(QuantumOperation):
     ) -> None:
         super().__init__(operation, qubit_support)
         self.generator = generator
+        if len(self.qubit_support) != int(log2(operation.shape[0])):
+            raise ValueError(
+                "The operation shape should match the legth of the qubit_support."
+            )
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -7,8 +7,8 @@ import torch
 from torch import Tensor
 
 from pyqtorch.embed import Embedding
-from pyqtorch.generic_quantum_ops import QuantumOperation
 from pyqtorch.matrices import OPERATIONS_DICT, _controlled
+from pyqtorch.quantum_ops import QuantumOperation
 from pyqtorch.utils import (
     product_state,
     qubit_support_as_tuple,

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from math import log2
+from typing import Any
 
 import torch
 from torch import Tensor
@@ -33,10 +33,12 @@ class Primitive(QuantumOperation):
     ) -> None:
         super().__init__(operation, qubit_support)
         self.generator = generator
-        if len(self.qubit_support) != int(log2(operation.shape[0])):
-            raise ValueError(
-                "The operation shape should match the legth of the qubit_support."
-            )
+
+    def to(self, *args: Any, **kwargs: Any) -> Primitive:
+        super().to(*args, **kwargs)
+        if self.generator is not None:
+            self.generator.to(*args, **kwargs)
+        return self
 
     @cached_property
     def eigenvals_generator(self) -> Tensor:

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -219,11 +219,13 @@ class SWAP(Primitive):
         super().__init__(OPERATIONS_DICT["SWAP"], (i, j))
 
 
-class CSWAP(ControlledPrimitive):
-    def __init__(self, control: int | tuple[int, ...], targets: tuple[int, ...]):
-        if not isinstance(targets, tuple) or len(targets) != 2:
+class CSWAP(Primitive):
+    def __init__(self, control: int, target: tuple[int, ...]):
+        if not isinstance(target, tuple) or len(target) != 2:
             raise ValueError("Target qubits must be a tuple with two qubits")
-        super().__init__(OPERATIONS_DICT["CSWAP"], control, targets)
+        self.control = get_tuple_qubit_support(control)
+        self.target = target
+        super().__init__(OPERATIONS_DICT["CSWAP"], self.control + self.target)
 
 
 class CNOT(ControlledPrimitive):

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -93,23 +93,23 @@ class ControlledPrimitive(Primitive):
 
 
 class X(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["X"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["X"], target)
 
 
 class Y(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["Y"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["Y"], target)
 
 
 class Z(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["Z"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["Z"], target)
 
 
 class I(Primitive):  # noqa: E742
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["I"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["I"], target)
 
     def forward(
         self,
@@ -131,26 +131,24 @@ class I(Primitive):  # noqa: E742
 
 
 class H(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["H"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["H"], target)
 
 
 class T(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["T"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["T"], target)
 
 
 class S(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(
-            OPERATIONS_DICT["S"], qubit_support, 0.5 * OPERATIONS_DICT["Z"]
-        )
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["S"], target, 0.5 * OPERATIONS_DICT["Z"])
 
 
 class SDagger(Primitive):
-    def __init__(self, qubit_support: int):
+    def __init__(self, target: int):
         super().__init__(
-            OPERATIONS_DICT["SDAGGER"], qubit_support, -0.5 * OPERATIONS_DICT["Z"]
+            OPERATIONS_DICT["SDAGGER"], target, -0.5 * OPERATIONS_DICT["Z"]
         )
 
 
@@ -170,8 +168,8 @@ class Projector(Primitive):
 
 
 class N(Primitive):
-    def __init__(self, qubit_support: int):
-        super().__init__(OPERATIONS_DICT["N"], qubit_support)
+    def __init__(self, target: int):
+        super().__init__(OPERATIONS_DICT["N"], target)
 
 
 class SWAP(Primitive):

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -10,8 +10,8 @@ from pyqtorch.embed import Embedding
 from pyqtorch.generic_quantum_ops import QuantumOperation
 from pyqtorch.matrices import OPERATIONS_DICT, _controlled
 from pyqtorch.utils import (
-    get_tuple_qubit_support,
     product_state,
+    qubit_support_as_tuple,
 )
 
 
@@ -63,8 +63,8 @@ class ControlledPrimitive(Primitive):
         control: int | tuple[int, ...],
         target: int | tuple[int, ...],
     ):
-        self.control = get_tuple_qubit_support(control)
-        self.target = get_tuple_qubit_support(target)
+        self.control = qubit_support_as_tuple(control)
+        self.target = qubit_support_as_tuple(target)
         if isinstance(operation, str):
             operation = OPERATIONS_DICT[operation]
         operation = _controlled(
@@ -133,7 +133,7 @@ class SDagger(Primitive):
 class Projector(Primitive):
     def __init__(self, qubit_support: int | tuple[int, ...], ket: str, bra: str):
 
-        qubit_support = get_tuple_qubit_support(qubit_support)
+        qubit_support = qubit_support_as_tuple(qubit_support)
         if len(ket) != len(bra):
             raise ValueError("Input ket and bra bitstrings must be of same length.")
         if len(qubit_support) != len(ket):
@@ -159,7 +159,7 @@ class CSWAP(Primitive):
     def __init__(self, control: int, target: tuple[int, ...]):
         if not isinstance(target, tuple) or len(target) != 2:
             raise ValueError("Target qubits must be a tuple with two qubits")
-        self.control = get_tuple_qubit_support(control)
+        self.control = qubit_support_as_tuple(control)
         self.target = target
         super().__init__(OPERATIONS_DICT["CSWAP"], self.control + self.target)
 

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -16,7 +16,7 @@ from pyqtorch.utils import (
 
 
 class Primitive(QuantumOperation):
-    """Primitive are fixed quantum operations with a defined
+    """Primitive are fixed quantum operations with a defined unitary operator U.
 
 
     Attributes:
@@ -35,6 +35,11 @@ class Primitive(QuantumOperation):
         self.generator = generator
 
     def to(self, *args: Any, **kwargs: Any) -> Primitive:
+        """Do device or dtype conversions.
+
+        Returns:
+            Primitive: Converted instance.
+        """
         super().to(*args, **kwargs)
         if self.generator is not None:
             self.generator.to(*args, **kwargs)
@@ -59,6 +64,14 @@ class Primitive(QuantumOperation):
 
 
 class ControlledPrimitive(Primitive):
+    """Primitive applied depending on control qubits.
+
+    Attributes:
+        operation (Tensor): Unitary tensor U.
+        control (int | tuple[int, ...]): List of qubits acting as controls.
+        target (int | tuple[int, ...]): List of qubits operations acts on.
+    """
+
     def __init__(
         self,
         operation: str | Tensor,
@@ -105,6 +118,16 @@ class I(Primitive):  # noqa: E742
         values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
     ) -> Tensor:
+        """Returns only state.
+
+        Args:
+            state (Tensor): Input state
+            values (dict[str, Tensor], optional): Parameter value. Defaults to dict().
+            embedding (Embedding | None, optional): Optional embedding. Defaults to None.
+
+        Returns:
+            Tensor: Input state.
+        """
         return state
 
 

--- a/pyqtorch/primitive.py
+++ b/pyqtorch/primitive.py
@@ -7,7 +7,7 @@ import torch
 from torch import Tensor
 
 from pyqtorch.embed import Embedding
-from pyqtorch.matrices import OPERATIONS_DICT, _controlled
+from pyqtorch.matrices import OPERATIONS_DICT, controlled
 from pyqtorch.quantum_ops import QuantumOperation, Support
 from pyqtorch.utils import (
     product_state,
@@ -16,11 +16,11 @@ from pyqtorch.utils import (
 
 
 class Primitive(QuantumOperation):
-    """Primitive are fixed quantum operations with a defined unitary operator U.
+    """Primitive operators based on a fixed matrix U.
 
 
     Attributes:
-        operation (Tensor): Unitary tensor U.
+        operation (Tensor): Matrix U.
         qubit_support: List of qubits the QuantumOperation acts on.
         generator (Tensor): A tensor G s.t. U = exp(-iG).
     """
@@ -81,8 +81,8 @@ class ControlledPrimitive(Primitive):
         support = Support(target, control)
         if isinstance(operation, str):
             operation = OPERATIONS_DICT[operation]
-        operation = _controlled(
-            unitary=operation.unsqueeze(2),
+        operation = controlled(
+            operation=operation.unsqueeze(2),
             batch_size=1,
             n_control_qubits=len(support.control),
         ).squeeze(2)

--- a/pyqtorch/quantum_ops.py
+++ b/pyqtorch/quantum_ops.py
@@ -256,7 +256,7 @@ class QuantumOperation(torch.nn.Module):
         values: dict[str, Tensor] | Tensor = dict(),
         embedding: Embedding | None = None,
     ) -> Tensor:
-        """Default operator_function returns symply the operation.
+        """Default operator_function simply returns the operation.
 
         Args:
             values (dict[str, Tensor] | Tensor, optional): Parameter values. Defaults to dict().

--- a/pyqtorch/quantum_ops.py
+++ b/pyqtorch/quantum_ops.py
@@ -42,8 +42,6 @@ class QuantumOperation(torch.nn.Module):
     """Generic QuantumOperation class storing a tensor operation to represent either
         a quantum operator or a tensor generator inferring the QuantumOperation.
 
-    Note that the methods below are meant
-
     Attributes:
         operation (Tensor): Tensor used to infer the QuantumOperation
             directly or indirectly.
@@ -219,7 +217,6 @@ class QuantumOperation(torch.nn.Module):
         values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
-        diagonal: bool = False,
     ) -> Tensor:
         """Get unitary tensor of the QuantumOperation.
 
@@ -228,16 +225,10 @@ class QuantumOperation(torch.nn.Module):
             embedding (Embedding | None, optional): Optional embedding. Defaults to None.
             full_support (tuple[int, ...] | None, optional): The qubits the returned tensor
                 will be defined over. Defaults to None for only using the qubit_support.
-            diagonal (bool, optional): If operator is diagonal. Defaults to False.
-
-        Raises:
-            NotImplementedError: If diagonal is used.
 
         Returns:
             Tensor: Unitary tensor of QuantumOperation.
         """
-        if diagonal:
-            raise NotImplementedError
         blockmat = self.operator_function(values, embedding)
         if self._qubit_support != self.qubit_support:
             blockmat = permute_basis(blockmat, self._qubit_support)

--- a/pyqtorch/quantum_ops.py
+++ b/pyqtorch/quantum_ops.py
@@ -277,14 +277,14 @@ class QuantumOperation(torch.nn.Module):
         values: dict[str, Tensor] | Tensor = dict(),
         embedding: Embedding | None = None,
     ) -> Tensor:
-        """Apply the dagger to unitary operator.
+        """Apply the dagger to operator.
 
         Args:
             values (dict[str, Tensor] | Tensor, optional): Parameter values. Defaults to dict().
             embedding (Embedding | None, optional): Optional embedding. Defaults to None.
 
         Returns:
-            Tensor: unitary dagged operator.
+            Tensor: dagged operator.
         """
         return _dagger(self.operator_function(values, embedding))
 
@@ -294,7 +294,7 @@ class QuantumOperation(torch.nn.Module):
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
     ) -> Tensor:
-        """Get unitary tensor of the QuantumOperation.
+        """Get tensor of the QuantumOperation.
 
         Args:
             values (dict[str, Tensor], optional): Parameter values. Defaults to dict().
@@ -303,7 +303,7 @@ class QuantumOperation(torch.nn.Module):
                 will be defined over. Defaults to None for only using the qubit_support.
 
         Returns:
-            Tensor: Unitary tensor of QuantumOperation.
+            Tensor: Tensor representation of QuantumOperation.
         """
         blockmat = self.operator_function(values, embedding)
         if self._qubit_support.qubits != self.qubit_support:

--- a/pyqtorch/quantum_ops.py
+++ b/pyqtorch/quantum_ops.py
@@ -284,7 +284,7 @@ class QuantumOperation(torch.nn.Module):
             embedding (Embedding | None, optional): Optional embedding. Defaults to None.
 
         Returns:
-            Tensor: dagged operator.
+            Tensor: conjugate transpose operator.
         """
         return _dagger(self.operator_function(values, embedding))
 

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -423,8 +423,8 @@ def promote_operator(operator: Tensor, target: int, n_qubits: int) -> Tensor:
     for qubit in qubits:
         operator = torch.where(
             target > qubit,
-            operator_kron(I(target).unitary(), operator),
-            operator_kron(operator, I(target).unitary()),
+            operator_kron(I(target).tensor(), operator),
+            operator_kron(operator, I(target).tensor()),
         )
     return operator
 

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -43,7 +43,7 @@ def qubit_support_as_tuple(support: int | tuple[int, ...]) -> tuple[int, ...]:
         tuple[int, ...]: Qubit support as tuple.
     """
     if isinstance(support, np.integer):
-        return (qubit_support.item(),)
+        return (support.item(),)
     qubit_support = (support,) if isinstance(support, int) else tuple(support)
     return qubit_support
 

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -42,9 +42,9 @@ def qubit_support_as_tuple(support: int | tuple[int, ...]) -> tuple[int, ...]:
     Returns:
         tuple[int, ...]: Qubit support as tuple.
     """
-    qubit_support = (support,) if isinstance(support, int) else support
-    if isinstance(qubit_support, np.integer):
-        qubit_support = (qubit_support.item(),)
+    if isinstance(support, np.integer):
+        return (qubit_support.item(),)
+    qubit_support = (support,) if isinstance(support, int) else tuple(support)
     return qubit_support
 
 

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -33,7 +33,7 @@ ABC_ARRAY: NDArray = array(list(ABC))
 logger = getLogger(__name__)
 
 
-def get_tuple_qubit_support(support: int | tuple[int, ...]) -> tuple[int, ...]:
+def qubit_support_as_tuple(support: int | tuple[int, ...]) -> tuple[int, ...]:
     """Make sure support returned is a tuple of integers.
 
     Args:

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -10,6 +10,7 @@ from math import sqrt
 from string import ascii_uppercase as ABC
 from typing import Any, Callable, Sequence
 
+import numpy as np
 import torch
 from numpy import arange, argsort, array, delete, log2
 from numpy import ndarray as NDArray
@@ -30,6 +31,21 @@ GPSR_ACCEPTANCE = 1e-05
 ABC_ARRAY: NDArray = array(list(ABC))
 
 logger = getLogger(__name__)
+
+
+def get_tuple_qubit_support(support: int | tuple[int, ...]) -> tuple[int, ...]:
+    """Make sure support returned is a tuple of integers.
+
+    Args:
+        support (int | tuple[int, ...]): Qubit support.
+
+    Returns:
+        tuple[int, ...]: Qubit support as tuple.
+    """
+    qubit_support = (support,) if isinstance(support, int) else support
+    if isinstance(qubit_support, np.integer):
+        qubit_support = (qubit_support.item(),)
+    return qubit_support
 
 
 def inner_prod(bra: Tensor, ket: Tensor) -> Tensor:

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -299,7 +299,7 @@ def test_dagger_single_qubit() -> None:
             values = (
                 {param_name: torch.rand(1)} if param_name == "theta" else torch.rand(1)
             )
-            new_state = apply_operator(state, op.unitary(values), [target])
+            new_state = apply_operator(state, op.tensor(values), [target])
             daggered_back = apply_operator(new_state, op.dagger(values), [target])
             assert torch.allclose(daggered_back, state)
 
@@ -332,7 +332,7 @@ def test_dagger_nqubit() -> None:
             values = (
                 {param_name: torch.rand(1)} if param_name == "theta" else torch.rand(1)
             )
-            new_state = apply_operator(state, op.unitary(values), qubit_support)
+            new_state = apply_operator(state, op.tensor(values), qubit_support)
             daggered_back = apply_operator(new_state, op.dagger(values), qubit_support)
             assert torch.allclose(daggered_back, state)
 
@@ -377,7 +377,7 @@ def test_dm(n_qubits: int, batch_size: int) -> None:
 
 
 def test_promote(random_gate: Primitive, n_qubits: int, target: int) -> None:
-    op_prom = promote_operator(random_gate.unitary(), target, n_qubits)
+    op_prom = promote_operator(random_gate.tensor(), target, n_qubits)
     assert op_prom.size() == torch.Size([2**n_qubits, 2**n_qubits, 1])
     assert torch.allclose(
         operator_product(op_prom, _dagger(op_prom), target),
@@ -390,11 +390,9 @@ def test_operator_product(random_gate: Primitive, n_qubits: int, target: int) ->
     batch_size_1 = torch.randint(low=1, high=5, size=(1,)).item()
     batch_size_2 = torch.randint(low=1, high=5, size=(1,)).item()
     max_batch = max(batch_size_2, batch_size_1)
-    op_prom = promote_operator(op.unitary(), target, n_qubits).repeat(
-        1, 1, batch_size_1
-    )
+    op_prom = promote_operator(op.tensor(), target, n_qubits).repeat(1, 1, batch_size_1)
     op_mul = operator_product(
-        op.unitary().repeat(1, 1, batch_size_2), _dagger(op_prom), target
+        op.tensor().repeat(1, 1, batch_size_2), _dagger(op_prom), target
     )
     assert op_mul.size() == torch.Size([2**n_qubits, 2**n_qubits, max_batch])
     assert torch.allclose(
@@ -425,8 +423,8 @@ def test_operator_kron(operator: Tensor, matrix: Tensor) -> None:
     kron_expect = torch.cat(krons, dim=2)
     assert torch.allclose(kron_out, kron_expect)
     assert torch.allclose(
-        torch.kron(operator(0).dagger().contiguous(), I(0).unitary()),
-        operator_kron(operator(0).dagger(), I(0).unitary()),
+        torch.kron(operator(0).dagger().contiguous(), I(0).tensor()),
+        operator_kron(operator(0).dagger(), I(0).tensor()),
     )
 
 

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -547,9 +547,9 @@ def test_dm_partial_trace() -> None:
     rho_sub = torch.from_numpy(
         array(
             [
-                Qobj(
-                    rollaxis(rho_list.numpy(), 2, 0)[i], dims=[[2] * n_qubits] * 2
-                ).ptrace(sort(keep_indices)).full()
+                Qobj(rollaxis(rho_list.numpy(), 2, 0)[i], dims=[[2] * n_qubits] * 2)
+                .ptrace(sort(keep_indices))
+                .full()
                 for i in range(batch_size)
             ]
         )

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -544,13 +544,12 @@ def test_dm_partial_trace() -> None:
 
     # testing reduced density matrix
     rho_list = generate_dm(n_qubits, batch_size)
-
     rho_sub = torch.from_numpy(
         array(
             [
                 Qobj(
                     rollaxis(rho_list.numpy(), 2, 0)[i], dims=[[2] * n_qubits] * 2
-                ).ptrace(sort(keep_indices))
+                ).ptrace(sort(keep_indices)).full()
                 for i in range(batch_size)
             ]
         )


### PR DESCRIPTION
To tackle issue #240 : 
- [x] Make property `qubit_support`
- [x] Create a generic `QuantumOperation ` factoring many common operations of `Primitive` and `Parametric`
Such class requires a tensor operator and a function to get a basic operator representation, to be used later in the tensor method. Doing so, we can define both Primitive and Parametric quantum operations, but probably more custom/advanced quantum operations later.
- [x] Inheritance redefined for `Primitive, `Parametric`, and Controlled classes.
- [x]  Replacing the `unitary` method by `tensor`
- [x] Cascading changes to other classes/functions for compatibility.