### PR TITLE
[Feature, Testing] Allow nested calls to ConcretizedCallable, more tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ serve = "mkdocs serve --dev-addr localhost:8000"
 
 [tool.ruff]
 lint.select = ["E", "F", "I", "Q"]
-lint.extend-ignore = ["F841"]
+lint.extend-ignore = ["F841", "E731"]
 line-length = 100
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "pyqtorch"
 description = "An efficient, large-scale emulator designed for quantum machine learning, seamlessly integrated with a PyTorch backend. Please refer to https://pyqtorch.readthedocs.io/en/latest/ for setup and usage info, along with the full documentation."
 readme = "README.md"
-version = "1.4.9"
+version = "1.5.0"
 requires-python = ">=3.8,<3.13"
 license = { text = "Apache 2.0" }
 keywords = ["quantum"]

--- a/pyqtorch/__init__.py
+++ b/pyqtorch/__init__.py
@@ -58,15 +58,10 @@ from .composite import (
 from .embed import (
     ConcretizedCallable,
     Embedding,
-    add,
     cos,
-    div,
     log,
-    mul,
     sin,
     sqrt,
-    square,
-    sub,
     tan,
     tanh,
 )

--- a/pyqtorch/__init__.py
+++ b/pyqtorch/__init__.py
@@ -58,10 +58,15 @@ from .composite import (
 from .embed import (
     ConcretizedCallable,
     Embedding,
+    add,
     cos,
+    div,
     log,
+    mul,
     sin,
     sqrt,
+    square,
+    sub,
     tan,
     tanh,
 )

--- a/pyqtorch/__init__.py
+++ b/pyqtorch/__init__.py
@@ -55,7 +55,21 @@ from .composite import (
     Scale,
     Sequence,
 )
-from .embed import ConcretizedCallable, Embedding
+from .embed import (
+    ConcretizedCallable,
+    Embedding,
+    add,
+    cos,
+    div,
+    log,
+    mul,
+    sin,
+    sqrt,
+    square,
+    sub,
+    tan,
+    tanh,
+)
 from .hamiltonians import HamiltonianEvolution, Observable
 from .noise import (
     AmplitudeDamping,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -10,7 +10,7 @@ from torch import Tensor, einsum, rand
 from torch.nn import Module, ModuleList, ParameterDict
 
 from pyqtorch.apply import apply_operator
-from pyqtorch.embed import ConcretizedCallable, Embedding
+from pyqtorch.embed import Embedding
 from pyqtorch.matrices import add_batch_dim
 from pyqtorch.primitives import CNOT, RX, RY, Parametric, Primitive
 from pyqtorch.utils import (
@@ -37,7 +37,7 @@ class Scale(Sequence):
     def __init__(
         self,
         operations: Union[Primitive, Sequence, Add],
-        param_name: str | Tensor | ConcretizedCallable,
+        param_name: str | Tensor,
     ):
         """
         Initializes a Scale object.
@@ -75,8 +75,6 @@ class Scale(Sequence):
             scale = values[self.param_name]
         elif isinstance(self.param_name, Tensor):
             scale = self.param_name
-        elif isinstance(self.param_name, ConcretizedCallable):
-            scale = self.param_name(values)
 
         return scale * self.operations[0].forward(state, values)
 
@@ -105,8 +103,6 @@ class Scale(Sequence):
             scale = values[self.param_name]
         elif isinstance(self.param_name, Tensor):
             scale = self.param_name
-        elif isinstance(self.param_name, ConcretizedCallable):
-            scale = self.param_name(values)
 
         return scale * self.operations[0].tensor(values, full_support=full_support)
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -76,8 +76,7 @@ class Scale(Sequence):
             if isinstance(self.param_name, str)
             else self.param_name
         )
-
-        return scale * self.operations[0].forward(state, values)
+        return scale * self.operations[0].forward(state, values, embedding)
 
     def tensor(
         self,
@@ -105,7 +104,7 @@ class Scale(Sequence):
             if isinstance(self.param_name, str)
             else self.param_name
         )
-        return scale * self.operations[0].tensor(values, embedding, full_support=full_support)
+        return scale * self.operations[0].tensor(values, embedding, full_support)
 
     def flatten(self) -> list[Scale]:
         """This method should only be called in the AdjointExpectation,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -71,10 +71,11 @@ class Scale(Sequence):
         if embedding is not None:
             values = embedding(values)
 
-        if isinstance(self.param_name, str):
-            scale = values[self.param_name]
-        elif isinstance(self.param_name, Tensor):
-            scale = self.param_name
+        scale = (
+            values[self.param_name]
+            if isinstance(self.param_name, str)
+            else self.param_name
+        )
 
         return scale * self.operations[0].forward(state, values)
 
@@ -99,10 +100,11 @@ class Scale(Sequence):
         if embedding is not None:
             values = embedding(values)
 
-        if isinstance(self.param_name, str):
-            scale = values[self.param_name]
-        elif isinstance(self.param_name, Tensor):
-            scale = self.param_name
+        scale = (
+            values[self.param_name]
+            if isinstance(self.param_name, str)
+            else self.param_name
+        )
 
         return scale * self.operations[0].tensor(values, full_support=full_support)
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -105,8 +105,7 @@ class Scale(Sequence):
             if isinstance(self.param_name, str)
             else self.param_name
         )
-
-        return scale * self.operations[0].tensor(values, full_support=full_support)
+        return scale * self.operations[0].tensor(values, embedding, full_support=full_support)
 
     def flatten(self) -> list[Scale]:
         """This method should only be called in the AdjointExpectation,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -37,7 +37,7 @@ class Scale(Sequence):
     def __init__(
         self,
         operations: Union[Primitive, Sequence, Add],
-        param_name: str | Tensor,
+        param_name: str | float | int | Tensor | ConcretizedCallable,
     ):
         """
         Initializes a Scale object.
@@ -48,6 +48,11 @@ class Scale(Sequence):
         """
         if not isinstance(operations, (Primitive, Sequence, Add)):
             raise ValueError("Scale only supports a single operation, Sequence or Add.")
+        if not isinstance(param_name, (str, int, float, Tensor, ConcretizedCallable)):
+            raise TypeError(
+                "Only str, int, float, Tensor or ConcretizedCallable types \
+                are supported for param_name"
+            )
         super().__init__([operations])
         self.param_name = param_name
 
@@ -127,7 +132,7 @@ class Scale(Sequence):
             Converted Scale.
         """
         super().to(*args, **kwargs)
-        if not isinstance(self.param_name, str):
+        if not isinstance(self.param_name, (str, float, int)):
             self.param_name = self.param_name.to(*args, **kwargs)
 
         return self

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -10,7 +10,7 @@ from torch import Tensor, einsum, rand
 from torch.nn import Module, ModuleList, ParameterDict
 
 from pyqtorch.apply import apply_operator
-from pyqtorch.embed import Embedding
+from pyqtorch.embed import ConcretizedCallable, Embedding
 from pyqtorch.matrices import add_batch_dim
 from pyqtorch.primitives import CNOT, RX, RY, Parametric, Primitive
 from pyqtorch.utils import (
@@ -71,12 +71,14 @@ class Scale(Sequence):
         if embedding is not None:
             values = embedding(values)
 
-        scale = (
-            values[self.param_name]
-            if isinstance(self.param_name, str)
-            else self.param_name
-        )
-        return scale * self.operations[0].forward(state, values, embedding)
+        if isinstance(self.param_name, str):
+            scale = values[self.param_name]
+        elif isinstance(self.param_name, Tensor):
+            scale = self.param_name
+        elif isinstance(self.param_name, ConcretizedCallable):
+            scale = self.param_name(values)
+
+        return scale * self.operations[0].forward(state, values)
 
     def tensor(
         self,
@@ -99,12 +101,14 @@ class Scale(Sequence):
         if embedding is not None:
             values = embedding(values)
 
-        scale = (
-            values[self.param_name]
-            if isinstance(self.param_name, str)
-            else self.param_name
-        )
-        return scale * self.operations[0].tensor(values, embedding, full_support)
+        if isinstance(self.param_name, str):
+            scale = values[self.param_name]
+        elif isinstance(self.param_name, Tensor):
+            scale = self.param_name
+        elif isinstance(self.param_name, ConcretizedCallable):
+            scale = self.param_name(values)
+
+        return scale * self.operations[0].tensor(values, full_support=full_support)
 
     def flatten(self) -> list[Scale]:
         """This method should only be called in the AdjointExpectation,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -10,7 +10,7 @@ from torch import Tensor, einsum, rand
 from torch.nn import Module, ModuleList, ParameterDict
 
 from pyqtorch.apply import apply_operator
-from pyqtorch.embed import Embedding
+from pyqtorch.embed import ConcretizedCallable, Embedding
 from pyqtorch.matrices import add_batch_dim
 from pyqtorch.primitives import CNOT, RX, RY, Parametric, Primitive
 from pyqtorch.utils import (
@@ -71,12 +71,14 @@ class Scale(Sequence):
         if embedding is not None:
             values = embedding(values)
 
-        scale = (
-            values[self.param_name]
-            if isinstance(self.param_name, str)
-            else self.param_name
-        )
-        return scale * self.operations[0].forward(state, values, embedding)
+        if isinstance(self.param_name, str):
+            scale = values[self.param_name]
+        elif isinstance(self.param_name, Tensor):
+            scale = self.param_name
+        elif isinstance(self.param_name, ConcretizedCallable):
+            scale = self.param_name(values)
+
+        return scale * self.operations[0].forward(state, values)
 
     def tensor(
         self,
@@ -99,12 +101,14 @@ class Scale(Sequence):
         if embedding is not None:
             values = embedding(values)
 
-        scale = (
-            values[self.param_name]
-            if isinstance(self.param_name, str)
-            else self.param_name
-        )
-        return scale * self.operations[0].tensor(values, embedding, full_support)
+        if isinstance(self.param_name, str):
+            scale = values[self.param_name]
+        elif isinstance(self.param_name, (Tensor, int, float)):
+            scale = self.param_name
+        elif isinstance(self.param_name, ConcretizedCallable):
+            scale = self.param_name(values)
+
+        return scale * self.operations[0].tensor(values, full_support=full_support)
 
     def flatten(self) -> list[Scale]:
         """This method should only be called in the AdjointExpectation,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -37,7 +37,7 @@ class Scale(Sequence):
     def __init__(
         self,
         operations: Union[Primitive, Sequence, Add],
-        param_name: str | Tensor,
+        param_name: str | Tensor | ConcretizedCallable,
     ):
         """
         Initializes a Scale object.

--- a/pyqtorch/differentiation/adjoint.py
+++ b/pyqtorch/differentiation/adjoint.py
@@ -130,8 +130,8 @@ class AdjointExpectation(Function):
                         grad_out * 2 * inner_prod(ctx.projected_state, mu).real
                     )
 
-                if values[op.param_name].requires_grad:
-                    grads_dict[op.param_name] = grad_out * 2 * -values[op.param_name]
+                if values[op.param_name].requires_grad:  # type: ignore [index]
+                    grads_dict[op.param_name] = grad_out * 2 * -values[op.param_name]  # type: ignore [index]
                 ctx.projected_state = apply_operator(
                     ctx.projected_state,
                     op.dagger(values, ctx.embedding),

--- a/pyqtorch/embed.py
+++ b/pyqtorch/embed.py
@@ -22,7 +22,7 @@ DEFAULT_JAX_MAPPING = {
     "sub": ("jax.numpy", "subtract"),
     "div": ("jax.numpy", "divide"),
 }
-DEFAULT_TORCH_MAPPING: dict = dict()
+DEFAULT_TORCH_MAPPING = {"hs": ("pyqtorch.utils", "heaviside")}
 DEFAULT_NUMPY_MAPPING = {
     "mul": ("numpy", "multiply"),
     "sub": ("numpy", "subtract"),

--- a/pyqtorch/embed.py
+++ b/pyqtorch/embed.py
@@ -75,7 +75,7 @@ class ConcretizedCallable:
     def __init__(
         self,
         call_name: str,
-        abstract_args: list[str | float | int],
+        abstract_args: list[str | float | int | ConcretizedCallable],
         instruction_mapping: dict[str, Tuple[str, str]] = dict(),
         engine_name: str = "torch",
         device: str = "cpu",
@@ -113,6 +113,8 @@ class ConcretizedCallable:
     def evaluate(self, inputs: dict[str, ArrayLike] = dict()) -> ArrayLike:
         arraylike_args = []
         for symbol_or_numeric in self.abstract_args:
+            if isinstance(symbol_or_numeric, ConcretizedCallable):
+                arraylike_args.append(symbol_or_numeric(inputs))
             if isinstance(symbol_or_numeric, (float, int)):
                 arraylike_args.append(
                     self.arraylike_fn(symbol_or_numeric, device=self.device)
@@ -148,6 +150,50 @@ def init_param(
         return engine.rand(1, requires_grad=trainable, device=device)
     elif engine_name == "numpy":
         return engine.random.uniform(0, 1)
+
+
+def sin(x: str | ConcretizedCallable):
+    return ConcretizedCallable("sin", [x])
+
+
+def cos(x: str | ConcretizedCallable):
+    return ConcretizedCallable("cos", [x])
+
+
+def log(x: str | ConcretizedCallable):
+    return ConcretizedCallable("log", [x])
+
+
+def tan(x: str | ConcretizedCallable):
+    return ConcretizedCallable("tan", [x])
+
+
+def tanh(x: str | ConcretizedCallable):
+    return ConcretizedCallable("tanh", [x])
+
+
+def sqrt(x: str | ConcretizedCallable):
+    return ConcretizedCallable("sqrt", [x])
+
+
+def square(x: str | ConcretizedCallable):
+    return ConcretizedCallable("square", [x])
+
+
+def mul(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("mul", [x, y])
+
+
+def add(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("add", [x, y])
+
+
+def div(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("div", [x, y])
+
+
+def sub(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("sub", [x, y])
 
 
 class Embedding:

--- a/pyqtorch/embed.py
+++ b/pyqtorch/embed.py
@@ -93,6 +93,16 @@ class ConcretizedCallable:
         self._dtype = dtype
         self.engine_call = None
         engine = None
+        if not all(
+            [
+                isinstance(arg, (str, float, int, complex, Tensor, ConcretizedCallable))
+                for arg in abstract_args
+            ]
+        ):
+            raise TypeError(
+                "Only str, float, int, complex, Tensor or ConcretizedCallable type elements \
+                are supported for abstract_args"
+            )
         try:
             engine_name, fn_name = ARRAYLIKE_FN_MAP[engine_name]
             engine = import_module(engine_name)

--- a/pyqtorch/embed.py
+++ b/pyqtorch/embed.py
@@ -252,26 +252,6 @@ def sqrt(x: str | ConcretizedCallable):
     return ConcretizedCallable("sqrt", [x])
 
 
-def square(x: str | ConcretizedCallable):
-    return ConcretizedCallable("square", [x])
-
-
-def mul(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("mul", [x, y])
-
-
-def add(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("add", [x, y])
-
-
-def div(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("div", [x, y])
-
-
-def sub(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("sub", [x, y])
-
-
 class Embedding:
     """A class relating variational and feature parameters used in ConcretizedCallable instances to
     parameter names used in gates.

--- a/pyqtorch/embed.py
+++ b/pyqtorch/embed.py
@@ -75,7 +75,7 @@ class ConcretizedCallable:
     def __init__(
         self,
         call_name: str,
-        abstract_args: list[str | float | int | ConcretizedCallable],
+        abstract_args: list[str | float | int | complex | ConcretizedCallable],
         instruction_mapping: dict[str, Tuple[str, str]] = dict(),
         engine_name: str = "torch",
         device: str = "cpu",
@@ -126,6 +126,59 @@ class ConcretizedCallable:
     def __call__(self, inputs: dict[str, ArrayLike] = dict()) -> ArrayLike:
         return self.evaluate(inputs)
 
+    def __mul__(
+        self, other: str | int | float | complex | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("mul", [self, other])
+
+    def __rmul__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("mul", [other, self])
+
+    def __add__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("add", [self, other])
+
+    def __radd__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("add", [other, self])
+
+    def __sub__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("sub", [self, other])
+
+    def __rsub__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("sub", [other, self])
+
+    def __pow__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("pow", [self, other])
+
+    def __rpow__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("pow", [other, self])
+
+    def __truediv__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("div", [self, other])
+
+    def __rtruediv__(
+        self, other: str | int | float | ConcretizedCallable
+    ) -> ConcretizedCallable:
+        return ConcretizedCallable("div", [other, self])
+
+    def __neg__(self) -> ConcretizedCallable:
+        return -1 * self
+
     @property
     def device(self) -> str:
         return self._device
@@ -174,26 +227,6 @@ def tanh(x: str | ConcretizedCallable):
 
 def sqrt(x: str | ConcretizedCallable):
     return ConcretizedCallable("sqrt", [x])
-
-
-def square(x: str | ConcretizedCallable):
-    return ConcretizedCallable("square", [x])
-
-
-def mul(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("mul", [x, y])
-
-
-def add(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("add", [x, y])
-
-
-def div(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("div", [x, y])
-
-
-def sub(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
-    return ConcretizedCallable("sub", [x, y])
 
 
 class Embedding:

--- a/pyqtorch/embed.py
+++ b/pyqtorch/embed.py
@@ -252,6 +252,26 @@ def sqrt(x: str | ConcretizedCallable):
     return ConcretizedCallable("sqrt", [x])
 
 
+def square(x: str | ConcretizedCallable):
+    return ConcretizedCallable("square", [x])
+
+
+def mul(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("mul", [x, y])
+
+
+def add(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("add", [x, y])
+
+
+def div(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("div", [x, y])
+
+
+def sub(x: str | ConcretizedCallable, y: str | ConcretizedCallable):
+    return ConcretizedCallable("sub", [x, y])
+
+
 class Embedding:
     """A class relating variational and feature parameters used in ConcretizedCallable instances to
     parameter names used in gates.

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -174,10 +174,6 @@ class HamiltonianEvolution(Sequence):
         else:
             raise ValueError("time should be passed as str or tensor.")
 
-        print()
-        print("generator:")
-        print(generator)
-
         self.has_time_param = self._has_time_param(generator)
 
         if isinstance(generator, Tensor):
@@ -268,11 +264,8 @@ class HamiltonianEvolution(Sequence):
         if isinstance(self.time, Tensor):
             return res
         else:
-            print("---- genrator:", generator, type(generator))
             if isinstance(generator, (Sequence, QuantumOperation)):
                 for m in generator.modules():
-                    print("module:")
-                    print(m)
                     if isinstance(m, (Scale, Parametric)):
                         if self.time in getattr(m.param_name, "independent_args", []):
                             # param_name is a ConcretizedCallable object

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -174,6 +174,10 @@ class HamiltonianEvolution(Sequence):
         else:
             raise ValueError("time should be passed as str or tensor.")
 
+        print()
+        print("generator:")
+        print(generator)
+
         self.has_time_param = self._has_time_param(generator)
 
         if isinstance(generator, Tensor):
@@ -261,15 +265,20 @@ class HamiltonianEvolution(Sequence):
         from pyqtorch.primitives import Parametric
 
         res = False
-        if isinstance(self.time, (Tensor)):
+        if isinstance(self.time, Tensor):
             return res
         else:
-            if isinstance(generator, Sequence):
+            print("---- genrator:", generator, type(generator))
+            if isinstance(generator, (Sequence, QuantumOperation)):
                 for m in generator.modules():
+                    print("module:")
+                    print(m)
                     if isinstance(m, (Scale, Parametric)):
                         if self.time in getattr(m.param_name, "independent_args", []):
+                            # param_name is a ConcretizedCallable object
                             res = True
                         elif m.param_name == self.time:
+                            # param_name is a string
                             res = True
         return res
 

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -165,14 +165,12 @@ class HamiltonianEvolution(Sequence):
         self.duration = duration
         self.is_time_dependent = None
 
-        if (
-            isinstance(time, str)
-            or isinstance(time, Tensor)
-            or isinstance(time, ConcretizedCallable)
-        ):
+        if isinstance(time, (str, Tensor, ConcretizedCallable)):
             self.time = time
         else:
-            raise ValueError("time should be passed as str or tensor.")
+            raise ValueError(
+                "time should be passed as str, Tensor or ConcretizedCallable."
+            )
 
         self.has_time_param = self._has_time_param(generator)
 

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -456,10 +456,6 @@ class HamiltonianEvolution(Sequence):
             evolved_op = self._cache_hamiltonian_evo[values_cache_key]
         else:
             hamiltonian: torch.Tensor = self.create_hamiltonian(values, embedding)  # type: ignore [call-arg]
-            # time_evolution: torch.Tensor = (
-            #     values[self.time] if isinstance(self.time, str) else self.time
-            # )  # If `self.time` is a string / hence, a Parameter,
-            # # we expect the user to pass it in the `values` dict
 
             if isinstance(self.time, str):
                 time_evolution = values[self.time]

--- a/pyqtorch/primitives/parametric.py
+++ b/pyqtorch/primitives/parametric.py
@@ -6,7 +6,7 @@ from typing import Any, Tuple
 import torch
 from torch import Tensor
 
-from pyqtorch.embed import ConcretizedCallable, Embedding
+from pyqtorch.embed import Embedding
 from pyqtorch.matrices import (
     OPERATIONS_DICT,
     _jacobian,
@@ -34,7 +34,7 @@ class Parametric(QuantumOperation):
         self,
         generator: str | Tensor,
         qubit_support: int | tuple[int, ...] | Support,
-        param_name: str | int | float | torch.Tensor | ConcretizedCallable = "",
+        param_name: str | int | float | torch.Tensor = "",
         noise: NoiseProtocol | None = None,
     ):
         """Initializes Parametric.
@@ -105,20 +105,6 @@ class Parametric(QuantumOperation):
                 torch.tensor(self.param_name, device=self.device, dtype=self.dtype)
             )
 
-        def parse_concretized_callable(
-            values: dict[str, Tensor] | Tensor = dict(),
-            embedding: Embedding | None = None,
-        ) -> Tensor:
-            """Evaluate ConcretizedCallable object with given values.
-
-            Arguments:
-                values: A dict containing param_name:torch.Tensor pairs
-            Returns:
-                A Torch Tensor with which to evaluate the Parametric Gate.
-            """
-            # self.param_name will be a torch.Tensor
-            return Parametric._expand_values(self.param_name(values))  # type: ignore [operator]
-
         if param_name == "":
             self.parse_values = parse_tensor
             self.param_name = self.param_name
@@ -126,8 +112,6 @@ class Parametric(QuantumOperation):
             self.parse_values = parse_values
         elif isinstance(param_name, (float, int, torch.Tensor)):
             self.parse_values = parse_constant
-        elif isinstance(param_name, ConcretizedCallable):
-            self.parse_values = parse_concretized_callable
 
         # Parametric is defined by generator operation and a function
         # The function will use parsed parameter values to compute the unitary

--- a/pyqtorch/primitives/parametric.py
+++ b/pyqtorch/primitives/parametric.py
@@ -49,6 +49,11 @@ class Parametric(QuantumOperation):
         generator_operation = (
             OPERATIONS_DICT[generator] if isinstance(generator, str) else generator
         )
+        if not isinstance(param_name, (str, int, float, Tensor, ConcretizedCallable)):
+            raise TypeError(
+                "Only str, int, float, Tensor or ConcretizedCallable types \
+                are supported for param_name"
+            )
         self.param_name = param_name
 
         def parse_values(
@@ -116,7 +121,7 @@ class Parametric(QuantumOperation):
             Returns:
                 A Torch Tensor with which to evaluate the Parametric Gate.
             """
-            # self.param_name will be a torch.Tensor
+            # self.param_name will be a ConcretizedCallable
             return Parametric._expand_values(self.param_name(values))  # type: ignore [operator]
 
         if param_name == "":

--- a/pyqtorch/primitives/parametric.py
+++ b/pyqtorch/primitives/parametric.py
@@ -6,7 +6,7 @@ from typing import Any, Tuple
 import torch
 from torch import Tensor
 
-from pyqtorch.embed import Embedding
+from pyqtorch.embed import ConcretizedCallable, Embedding
 from pyqtorch.matrices import (
     OPERATIONS_DICT,
     _jacobian,
@@ -34,7 +34,7 @@ class Parametric(QuantumOperation):
         self,
         generator: str | Tensor,
         qubit_support: int | tuple[int, ...] | Support,
-        param_name: str | int | float | torch.Tensor = "",
+        param_name: str | int | float | torch.Tensor | ConcretizedCallable = "",
         noise: NoiseProtocol | None = None,
     ):
         """Initializes Parametric.
@@ -105,6 +105,20 @@ class Parametric(QuantumOperation):
                 torch.tensor(self.param_name, device=self.device, dtype=self.dtype)
             )
 
+        def parse_concretized_callable(
+            values: dict[str, Tensor] | Tensor = dict(),
+            embedding: Embedding | None = None,
+        ) -> Tensor:
+            """Evaluate ConcretizedCallable object with given values.
+
+            Arguments:
+                values: A dict containing param_name:torch.Tensor pairs
+            Returns:
+                A Torch Tensor with which to evaluate the Parametric Gate.
+            """
+            # self.param_name will be a torch.Tensor
+            return Parametric._expand_values(self.param_name(values))  # type: ignore [operator]
+
         if param_name == "":
             self.parse_values = parse_tensor
             self.param_name = self.param_name
@@ -112,6 +126,8 @@ class Parametric(QuantumOperation):
             self.parse_values = parse_values
         elif isinstance(param_name, (float, int, torch.Tensor)):
             self.parse_values = parse_constant
+        elif isinstance(param_name, ConcretizedCallable):
+            self.parse_values = parse_concretized_callable
 
         # Parametric is defined by generator operation and a function
         # The function will use parsed parameter values to compute the unitary

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -218,9 +218,7 @@ def is_diag(H: Tensor, atol: Tensor = ATOL) -> bool:
     Returns:
         True if diagonal, else False.
     """
-    m = H.shape[0]
-    p, q = H.stride()
-    offdiag_view = torch.as_strided(H[:, 1:], (m - 1, m), (p + q, q))
+    offdiag_view = H - torch.diag(torch.diag(H))
     return torch.count_nonzero(torch.abs(offdiag_view).gt(atol)) == 0
 
 

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -757,7 +757,6 @@ def is_parametric(operation: pyq.Sequence) -> bool:
 
 
 def heaviside(x: Tensor, _: Tensor) -> Tensor:
-    b = torch.zeros(2)
-    b[0] = x - 0.0
-    a = torch.clamp(1000 * torch.max(b), torch.tensor(0.0), torch.tensor(1.0))
-    return a
+    a = torch.zeros(2)
+    a[0] = x
+    return torch.clamp(1000 * torch.max(a), torch.tensor(0.0), torch.tensor(1.0))

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -754,3 +754,10 @@ def is_parametric(operation: pyq.Sequence) -> bool:
     if any(isinstance(p, (str, pyq.ConcretizedCallable)) for p in params):
         res = True
     return res
+
+
+def heaviside(x: Tensor, _: Tensor) -> Tensor:
+    b = torch.zeros(2)
+    b[0] = x - 0.0
+    a = torch.clamp(1000 * torch.max(b), torch.tensor(0.0), torch.tensor(1.0))
+    return a

--- a/pyqtorch/utils.py
+++ b/pyqtorch/utils.py
@@ -752,8 +752,7 @@ def is_parametric(operation: pyq.Sequence) -> bool:
     for m in operation.modules():
         if isinstance(m, (pyq.Scale, Parametric)):
             params.append(m.param_name)
-
     res = False
-    if any(isinstance(p, str) for p in params):
+    if any(isinstance(p, (str, pyq.ConcretizedCallable)) for p in params):
         res = True
     return res

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -94,6 +94,7 @@ def random_pauli_hamiltonian(
     k_1q: int = 5,
     k_2q: int = 10,
     make_param: bool = False,
+    make_embed: bool = False,
     default_scale_coeffs: float | None = None,
     p_param: float = 0.5,
 ) -> tuple[Sequence, list]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@ import random
 
 import torch
 
+import pyqtorch.embed as pyq_em
 from pyqtorch.apply import apply_operator, apply_operator_permute
 from pyqtorch.composite import Add, Scale, Sequence
 from pyqtorch.primitives import (
@@ -68,12 +69,31 @@ def get_op_support(
         return supp
 
 
+def get_random_embed() -> tuple:
+    fn_list = [
+        (pyq_em.sin, torch.sin),
+        (pyq_em.cos, torch.cos),
+        (pyq_em.log, torch.log),
+        (pyq_em.tanh, torch.tanh),
+        (pyq_em.tan, torch.tan),
+        (pyq_em.sqrt, torch.sqrt),
+    ]
+
+    fn1, fn2 = random.choice(fn_list), random.choice(fn_list)
+
+    expr = (1.0 + 2 ** fn1[0]("x")) * fn2[0]("x")
+    call = lambda x: (12.0 + 2 ** fn1[1](x)) * fn2[1]("x")
+
+    embedding = pyq_em.Embedding(fparam_names=["x"], var_to_call={"expr": expr})
+
+    return embedding, call
+
+
 def random_pauli_hamiltonian(
     n_qubits: int,
     k_1q: int = 5,
     k_2q: int = 10,
     make_param: bool = False,
-    make_embed: bool = False,
     default_scale_coeffs: float | None = None,
     p_param: float = 0.5,
 ) -> tuple[Sequence, list]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -94,7 +94,6 @@ def random_pauli_hamiltonian(
     k_1q: int = 5,
     k_2q: int = 10,
     make_param: bool = False,
-    make_embed: bool = False,
     default_scale_coeffs: float | None = None,
     p_param: float = 0.5,
 ) -> tuple[Sequence, list]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -73,6 +73,7 @@ def random_pauli_hamiltonian(
     k_1q: int = 5,
     k_2q: int = 10,
     make_param: bool = False,
+    make_embed: bool = False,
     default_scale_coeffs: float | None = None,
     p_param: float = 0.5,
 ) -> tuple[Sequence, list]:

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -319,7 +319,8 @@ def test_timedependent(
     )
     hamiltonian_evolution = pyq.HamiltonianEvolution(
         generator=hamevo_generator,
-        time=torch.as_tensor(duration),
+        time=tparam,
+        duration=duration,
         steps=n_steps,
         solver=ode_solver,
     )

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -409,6 +409,13 @@ def test_hamevo_parametric_gen(n_qubits: int, batch_size: int) -> None:
             "x",
             True,
         ),
+        (
+            Add(
+                [Scale(X(1), ConcretizedCallable("add", ["y", "x"])), Scale(X(1), "z")]
+            ),
+            "t",
+            False,
+        ),
     ],
 )
 def test_hamevo_is_time_dependent_generator(generator, time_param, result) -> None:

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -8,6 +8,7 @@ import torch
 from helpers import calc_mat_vec_wavefunction, random_pauli_hamiltonian
 
 import pyqtorch as pyq
+from pyqtorch import RX, Add, ConcretizedCallable, HamiltonianEvolution, Scale, X
 from pyqtorch.composite import Sequence
 from pyqtorch.hamiltonians import GeneratorType
 from pyqtorch.matrices import (
@@ -389,3 +390,27 @@ def test_hamevo_parametric_gen(n_qubits: int, batch_size: int) -> None:
     apply_hamevo_and_compare_expected(psi, values)
     assert len(hamevo._cache_hamiltonian_evo) == 2
     assert values_cache_key in previous_cache_keys
+
+
+@pytest.mark.parametrize(
+    "generator, time_param, result",
+    [
+        (RX(0, "x"), "x", True),
+        (RX(1, 0.5), "y", False),
+        (RX(0, "x"), "y", False),
+        (RX(0, "x"), torch.tensor(0.5), False),
+        (RX(0, torch.tensor(0.5)), torch.tensor(0.5), False),
+        (Scale(X(1), "y"), "y", True),
+        (Scale(X(1), 0.2), "x", False),
+        (
+            Add(
+                [Scale(X(1), ConcretizedCallable("mul", ["y", "x"])), Scale(X(1), "z")]
+            ),
+            "x",
+            True,
+        ),
+    ],
+)
+def test_hamevo_is_time_dependent_generator(generator, time_param, result) -> None:
+    hamevo = HamiltonianEvolution(generator, time_param)
+    assert hamevo.has_time_param == result

--- a/tests/test_digital.py
+++ b/tests/test_digital.py
@@ -9,6 +9,7 @@ import torch
 from torch import Tensor
 
 import pyqtorch as pyq
+from pyqtorch import ConcretizedCallable
 from pyqtorch.apply import apply_operator
 from pyqtorch.matrices import (
     DEFAULT_MATRIX_DTYPE,
@@ -339,4 +340,20 @@ def test_parametric_constantparam(gate: Parametric) -> None:
     assert torch.allclose(
         gate(target, "theta")(state, {"theta": param_val}),
         gate(target, param_val)(state),
+    )
+
+
+@pytest.mark.parametrize("gate", [pyq.RX, pyq.RY, pyq.RZ])
+def test_parametric_callableparam(gate: Parametric) -> None:
+    n_qubits = 4
+    max_batch_size = 10
+    target = torch.randint(0, n_qubits, (1,)).item()
+    size = torch.randint(1, max_batch_size, (1,)).item()
+    param_val_x = torch.rand(size)
+    param_val_y = torch.rand(size)
+    state = pyq.random_state(n_qubits)
+    param = ConcretizedCallable("add", ["x", "y"])
+    assert torch.allclose(
+        gate(target, param)(state, {"x": param_val_x, "y": param_val_y}),
+        gate(target, param_val_x + param_val_y)(state),
     )

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -10,7 +10,7 @@ import torch.autograd.gradcheck
 from torch.nn import Module
 
 import pyqtorch as pyq
-from pyqtorch.embed import ConcretizedCallable, Embedding
+from pyqtorch.embed import ConcretizedCallable, Embedding, cos, log, sin, sqrt
 from pyqtorch.primitives import Primitive
 from pyqtorch.utils import ATOL_embedding
 
@@ -226,3 +226,8 @@ def test_reembedding_forward() -> None:
     )
     wf = custom(state=pyq.zero_state(2), values={"t": torch.rand(1)}, embedding=embed)
     assert not torch.any(torch.isnan(wf))
+
+
+def test_get_independent_args() -> None:
+    expr: ConcretizedCallable = sqrt(sin("x")) + cos("r") * (1.0 / log("z") * "y")
+    assert set(expr.independent_args) == {"x", "y", "z", "r"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from pyqtorch import RX, RY, ConcretizedCallable, Scale, Sequence, X
+from pyqtorch.utils import heaviside, is_parametric
+
+
+@pytest.mark.parametrize(
+    "operation, result",
+    [
+        (RX(0, "x"), True),
+        (RY(1, 0.5), False),
+        (Scale(X(1), "y"), True),
+        (Scale(X(1), 0.2), False),
+        (Scale(X(1), ConcretizedCallable("mul", ["y", "x"])), True),
+    ],
+)
+def test_is_parametric(operation: Sequence, result: bool) -> None:
+    assert is_parametric(operation) == result
+
+
+def test_heaviside() -> None:
+    x = torch.linspace(-1, 1, 50)
+    assert torch.allclose(heaviside(x), torch.heaviside(x, torch.tensor(0.0)))


### PR DESCRIPTION
Extends the `ConcretizedCallable` to allow nested calls, adds some convenience functions. E.g. now we can write

```
import pyqtorch as pyq

## Creating an expression and embedding

expr = "z" ** pyq.log(1.0 / (1.0 + (2.0 * pyq.sin("x")) + "y"))

expr_name = "expr"

embedding = pyq.Embedding(
    fparam_names = ["x", "y"],
    vparam_names = ["z"],
    var_to_call = {"expr": expr}
)

## Passing the expression to a block parameter

op = pyq.Scale(pyq.I(0), "expr")

values = {"x": torch.tensor(1.0), "y": torch.tensor(-1.0),  "z": torch.tensor(2.0)}

matrix = op.tensor(values, embedding)

matrix[..., 0]

---

tensor([[0.6971, 0.0000],
        [0.0000, 0.6971]])
```

Furthermore, with the current change, we might not need the `Embedding` 🤔. To be explored in a later MR: https://github.com/pasqal-io/pyqtorch/issues/278