### PR TITLE
[Feature] Correlated readout and extending ReadoutNoise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8","3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
         - name: Checkout main code and submodules
           uses: actions/checkout@v4

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -153,7 +153,7 @@ theta = torch.rand(1, requires_grad=True)
 obs = pyq.Observable(pyq.Z(0))
 
 noiseless_expectation = pyq.expectation(circ, state, {"theta": theta}, observable=obs)
-readobj = ReadoutNoise(n_qubits, 0)
+readobj = ReadoutNoise(n_qubits, seed=0)
 noisycirc = pyq.QuantumCircuit(n_qubits, ops, readobj)
 noisy_expectation = pyq.expectation(noisycirc, state, {"theta": theta}, observable=obs, n_shots=1000)
 print("Noiseless expectation ", noiseless_expectation.item())

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -133,6 +133,9 @@ T(x|x')=\delta_{xx'}
 $$
 
 where $x$ represent a bitstring.
+We provide two ways to define readout errors:
+- `ReadoutNoise` : where each bit can be corrupted independently given an error probability or a 1D tensor of errors.
+- `CorrelatedReadoutNoise` : where we provide the full confusion matrix for all possible bitstrings.
 
 ```python exec="on" source="material-block"
 import torch

--- a/pyqtorch/api.py
+++ b/pyqtorch/api.py
@@ -174,7 +174,7 @@ def sampled_expectation(
     eigvec_state_prod = torch.flatten(eigvec_state_prod, start_dim=0, end_dim=-2).t()
     probs = torch.pow(torch.abs(eigvec_state_prod), 2)
     if circuit.readout_noise is not None:
-        batch_samples = circuit.readout_noise.apply_on_probas(probs, n_shots)
+        batch_samples = circuit.readout_noise.apply(probs, n_shots)
 
     batch_sample_multinomial = torch.func.vmap(
         lambda p: sample_multinomial(

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -11,7 +11,7 @@ from torch.nn import Module, ParameterDict
 
 from pyqtorch.composite import Sequence
 from pyqtorch.embed import Embedding
-from pyqtorch.noise import ReadoutNoise
+from pyqtorch.noise.readout import ReadoutInterface as Readout
 from pyqtorch.utils import (
     DensityMatrix,
     DropoutMode,
@@ -30,7 +30,7 @@ class QuantumCircuit(Sequence):
     Attributes:
         n_qubits (int): Number of qubits.
         operations (list[Module]): List of operations.
-        readout_noise (ReadoutNoise | None, optional): Readout noise
+        readout_noise (Readout | None, optional): Readout noise
             applied to samples. Defaults to None.
     """
 
@@ -38,7 +38,7 @@ class QuantumCircuit(Sequence):
         self,
         n_qubits: int,
         operations: list[Module],
-        readout_noise: ReadoutNoise | None = None,
+        readout_noise: Readout | None = None,
     ):
         """Initializes QuantumCircuit.
 
@@ -123,7 +123,7 @@ class DropoutQuantumCircuit(QuantumCircuit):
         self,
         n_qubits: int,
         operations: list[Module],
-        readout_noise: ReadoutNoise | None = None,
+        readout_noise: Readout | None = None,
         dropout_mode: DropoutMode = DropoutMode.ROTATIONAL,
         dropout_prob: float = 0.06,
     ):

--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -109,7 +109,7 @@ class QuantumCircuit(Sequence):
             if self.readout_noise is None:
                 return counters
 
-            return self.readout_noise.apply_on_counts(counters, n_shots)
+            return self.readout_noise.apply(counters, n_shots)
 
 
 class DropoutQuantumCircuit(QuantumCircuit):

--- a/pyqtorch/noise/__init__.py
+++ b/pyqtorch/noise/__init__.py
@@ -11,4 +11,4 @@ from .gates import (
     PhaseFlip,
 )
 from .protocol import NoiseProtocol, NoiseType, _repr_noise
-from .readout import ReadoutNoise, WhiteNoise
+from .readout import CorrelatedReadoutNoise, ReadoutNoise, WhiteNoise

--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -195,7 +195,7 @@ class ReadoutNoise(ReadoutInterface):
     def __init__(
         self,
         n_qubits: int,
-        error_probability: float | Tensor | None = None,
+        error_probability: float | Tensor = 0.1,
         seed: int | None = None,
         noise_distribution: torch.distributions | None = WhiteNoise.UNIFORM,
     ) -> None:
@@ -218,7 +218,6 @@ class ReadoutNoise(ReadoutInterface):
         """
         self.n_qubits = n_qubits
         self.seed = seed
-        self.error_probability = torch.tensor(0.1)
         size_error_probability = (1,)
         if error_probability is not None:
             if isinstance(error_probability, float):

--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -105,7 +105,7 @@ def bs_bitflip_corruption(
     given a noise matrix.
 
     Args:
-        err_idx (Tensor): A Boolean array of bit string indices that need to be corrupted.
+        err_idx (Tensor): A Boolean array of bit string indices to be corrupted.
         sample (Tensor): A torch.Tensor of bit strings n_shots x n_qubits.
 
     Returns:

--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -278,7 +278,7 @@ class ReadoutNoise(ReadoutInterface):
         return noise_matrix
 
     @singledispatchmethod
-    def apply(self, input_to_corrupt, n_shots: int):
+    def apply(self, input_to_corrupt, n_shots):
         raise NotImplementedError
 
     @apply.register
@@ -365,7 +365,7 @@ class CorrelatedReadoutNoise(ReadoutInterface):
         self.seed = seed
 
     @singledispatchmethod
-    def apply(self, input_to_corrupt, n_shots: int):
+    def apply(self, input_to_corrupt, n_shots):
         raise NotImplementedError
 
     @apply.register

--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -159,7 +159,7 @@ def create_confusion_matrices(noise_matrix: Tensor, error_probability: float) ->
 
 class ReadoutInterface(ABC):
     @singledispatchmethod
-    def apply(self, input_to_corrupt, n_shots: int):
+    def apply(self, input_to_corrupt, n_shots):
         raise NotImplementedError
 
 

--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -351,6 +351,7 @@ class CorrelatedReadoutNoise(ReadoutInterface):
     def __init__(
         self,
         confusion_matrix: Tensor,
+        seed: int | None = None,
     ) -> None:
         """Initializes CorrelatedReadoutNoise.
 
@@ -363,6 +364,7 @@ class CorrelatedReadoutNoise(ReadoutInterface):
             raise ValueError("The confusion matrix should be square")
         self.confusion_matrix = confusion_matrix
         self.n_qubits = int(log(confusion_matrix.size(0), 2))
+        self.seed = seed
 
     def apply_on_probas(self, batch_probs: Tensor, n_shots: int = 1000) -> Tensor:
         output_probs = batch_probs @ self.confusion_matrix.T
@@ -371,7 +373,8 @@ class CorrelatedReadoutNoise(ReadoutInterface):
     def apply_on_counts(
         self, counters: list[Counter | OrderedCounter], n_shots: int = 1000
     ) -> list[Counter]:
-
+        if self.seed is not None:
+            torch.manual_seed(self.seed)
         corrupted_bitstrings = []
         for counter in counters:
             sample = sample_to_matrix(counter)

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -10,7 +10,7 @@ import pyqtorch as pyq
 from pyqtorch.noise import ReadoutNoise
 from pyqtorch.noise.readout import (
     WhiteNoise,
-    bs_corruption,
+    bs_bitflip_corruption,
     create_noise_matrix,
     sample_to_matrix,
 )
@@ -46,7 +46,7 @@ def test_bitstring_corruption_all_bitflips(
     noise_matrix = create_noise_matrix(WhiteNoise.UNIFORM, n_shots, n_qubits)
     err_idx = torch.as_tensor(noise_matrix < error_probability)
     sample = sample_to_matrix(counters[0])
-    corrupted_counters = [bs_corruption(err_idx=err_idx, sample=sample)]
+    corrupted_counters = [bs_bitflip_corruption(err_idx=err_idx, sample=sample)]
     assert sum(corrupted_counters[0].values()) == n_shots
     assert corrupted_counters == exp_corrupted_counters
     assert torch.allclose(
@@ -75,7 +75,7 @@ def test_bitstring_corruption_mixed_bitflips(counters: list, n_qubits: int) -> N
     noise_matrix = create_noise_matrix(WhiteNoise.UNIFORM, n_shots, n_qubits)
     err_idx = torch.as_tensor(noise_matrix < error_probability)
     sample = sample_to_matrix(counters[0])
-    corrupted_counters = [bs_corruption(err_idx=err_idx, sample=sample)]
+    corrupted_counters = [bs_bitflip_corruption(err_idx=err_idx, sample=sample)]
     for noiseless, noisy in zip(counters, corrupted_counters):
         assert sum(noisy.values()) == n_shots
         assert js_divergence_counters(noiseless, noisy) >= 0.0

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -7,7 +7,7 @@ import pytest
 import torch
 
 import pyqtorch as pyq
-from pyqtorch.noise import ReadoutNoise
+from pyqtorch.noise import CorrelatedReadoutNoise, ReadoutNoise
 from pyqtorch.noise.readout import (
     WhiteNoise,
     bs_bitflip_corruption,
@@ -112,6 +112,28 @@ def test_readout_error_quantum_circuit(
         )
 
 
+def test_correlated_readout() -> None:
+    n_shots = 1000
+    confusion_matrix = torch.tensor(
+        [
+            [0.9, 0.05, 0.03, 0.02],
+            [0.05, 0.85, 0.05, 0.05],
+            [0.03, 0.05, 0.87, 0.05],
+            [0.02, 0.05, 0.05, 0.88],
+        ],
+        dtype=torch.float64,
+    )
+
+    corr_readout = CorrelatedReadoutNoise(confusion_matrix, 0)
+    probas = torch.tensor([[0.4, 0.3, 0.2, 0.1]], dtype=torch.double)
+    out_probas = corr_readout.apply_on_probas(probas)
+    assert torch.allclose(
+        out_probas,
+        torch.tensor([[0.3830, 0.2900, 0.2060, 0.1210]], dtype=torch.float64),
+        atol=1e-4,
+    )
+
+
 def test_readout_error_expectation() -> None:
 
     n_shots = 100
@@ -127,6 +149,19 @@ def test_readout_error_expectation() -> None:
 
     readout = ReadoutNoise(n_qubits, error_probability=0.1, seed=0)
     noisy_qc = pyq.QuantumCircuit(n_qubits, ops, readout)
+
+    confusion_matrix = torch.tensor(
+        [
+            [0.9, 0.05, 0.03, 0.02],
+            [0.05, 0.85, 0.05, 0.05],
+            [0.03, 0.05, 0.87, 0.05],
+            [0.02, 0.05, 0.05, 0.88],
+        ],
+        dtype=torch.float64,
+    )
+    readoutCorrelated = CorrelatedReadoutNoise(confusion_matrix, seed=0)
+
+    corr_noisy_qc = pyq.QuantumCircuit(n_qubits, ops, readoutCorrelated)
     assert not torch.allclose(
         pyq.expectation(
             noiseless_qc,
@@ -136,6 +171,17 @@ def test_readout_error_expectation() -> None:
         ),
         pyq.expectation(
             noisy_qc, initstate, {"theta": theta}, observable=obs, n_shots=n_shots
+        ),
+    )
+    assert not torch.allclose(
+        pyq.expectation(
+            noiseless_qc,
+            initstate,
+            {"theta": theta},
+            observable=obs,
+        ),
+        pyq.expectation(
+            corr_noisy_qc, initstate, {"theta": theta}, observable=obs, n_shots=n_shots
         ),
     )
 

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -126,7 +126,7 @@ def test_correlated_readout() -> None:
 
     corr_readout = CorrelatedReadoutNoise(confusion_matrix, 0)
     probas = torch.tensor([[0.4, 0.3, 0.2, 0.1]], dtype=torch.double)
-    out_probas = corr_readout.apply_on_probas(probas)
+    out_probas = corr_readout.apply(probas, n_shots=1000)
     assert torch.allclose(
         out_probas,
         torch.tensor([[0.3830, 0.2900, 0.2060, 0.1210]], dtype=torch.float64),
@@ -192,7 +192,7 @@ def test_readout_apply_probas() -> None:
     n_shots = 1000
     probas = torch.tensor([[0.4, 0.3, 0.2, 0.1]], dtype=torch.double)
     readobj = ReadoutNoise(2, seed=0)
-    out_probas = readobj.apply_on_probas(probas)
+    out_probas = readobj.apply(probas, n_shots=1000)
 
     assert torch.allclose(torch.sum(out_probas), torch.ones(1, dtype=out_probas.dtype))
     assert torch.allclose(


### PR DESCRIPTION
Closes #285 by adding correlated readout. Also, we extend ReadoutNoise to provide different `error_probability` tensors. Now we can provide a 1D tensor where each qubit has a different probability of corruption. Also we can provide a tensor of shape (n_qubits, 2, 2) that avoids recomputing the confusion_matrix if someone is interested in providing it from data, but we can still create noise matrices for corruption.