### PR TITLE
[Feature] Faster sample method with readout

### DIFF
--- a/pyqtorch/circuit.py
+++ b/pyqtorch/circuit.py
@@ -103,13 +103,12 @@ class QuantumCircuit(Sequence):
                 probs = torch.abs(torch.pow(state, 2))
 
             probs = torch.pow(torch.abs(state), 2)
+            if self.readout_noise is not None:
+                probs = self.readout_noise.apply(probs, n_shots)
             counters = list(
                 map(lambda p: sample_multinomial(p, self.n_qubits, n_shots), probs)
             )
-            if self.readout_noise is None:
-                return counters
-
-            return self.readout_noise.apply(counters, n_shots)
+            return counters
 
 
 class DropoutQuantumCircuit(QuantumCircuit):


### PR DESCRIPTION
Related to #296. 

Using the apply method on the probability vector directly in `QuantumCircuit.sample` leads to faster runtime (example on 10 qubits for 1e6 shots leads to runtime in ms instead of seconds). 