### PR TITLE
[Bugfix] Fix mean when empty tensor for readout

### DIFF
--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -148,7 +148,11 @@ def create_confusion_matrices(noise_matrix: Tensor, error_probability: float) ->
     confusion_matrices = []
     for i in range(noise_matrix.size()[1]):
         column_tensor = noise_matrix[:, i]
-        flip_proba = column_tensor[column_tensor < error_probability].mean().item()
+        flip_proba = column_tensor[column_tensor < error_probability]
+        if len(flip_proba) == 0:
+            flip_proba = 0.0
+        else:
+            flip_proba = flip_proba.mean().item()
         confusion_matrix = torch.tensor(
             [[1.0 - flip_proba, flip_proba], [flip_proba, 1.0 - flip_proba]],
             dtype=torch.float64,

--- a/pyqtorch/noise/readout.py
+++ b/pyqtorch/noise/readout.py
@@ -148,11 +148,11 @@ def create_confusion_matrices(noise_matrix: Tensor, error_probability: float) ->
     confusion_matrices = []
     for i in range(noise_matrix.size()[1]):
         column_tensor = noise_matrix[:, i]
-        flip_proba = column_tensor[column_tensor < error_probability]
-        if len(flip_proba) == 0:
-            flip_proba = 0.0
-        else:
-            flip_proba = flip_proba.mean().item()
+        flip_proba = (
+            flip_proba.mean().item()
+            if len(flip_proba := column_tensor[column_tensor < error_probability]) > 0
+            else 0.0
+        )
         confusion_matrix = torch.tensor(
             [[1.0 - flip_proba, flip_proba], [flip_proba, 1.0 - flip_proba]],
             dtype=torch.float64,

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -11,12 +11,24 @@ from pyqtorch.noise import CorrelatedReadoutNoise, ReadoutNoise
 from pyqtorch.noise.readout import (
     WhiteNoise,
     bs_bitflip_corruption,
+    create_confusion_matrices,
     create_noise_matrix,
     sample_to_matrix,
 )
 from pyqtorch.primitives import Primitive
 from pyqtorch.utils import sample_multinomial
 from pyqtorch.utils_distributions import js_divergence, js_divergence_counters
+
+
+def test_noise_matrix():
+    noise_mat = torch.tensor([[0.5679, 0.7676]])
+    zero_prob_mat = torch.tensor(
+        [[1.0, 0.0], [0.0, 1.0]],
+        dtype=torch.float64,
+    )
+    assert torch.allclose(
+        create_confusion_matrices(noise_mat, 0.1), torch.stack([zero_prob_mat] * 2)
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Solving the edge case when mean of an empty tensor returns nan