### PR TITLE
[Feature, Performance] Optimize HamiltonianEvolution for commuting hamiltonians

### DIFF
--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -244,7 +244,7 @@ class Add(Sequence):
             return False
         qubit_supports_intersect = [set(op.qubit_support) for op in self.operations]
 
-        disjoint_sets = set()
+        disjoint_sets: set[int] = set()
         for s in qubit_supports_intersect:
             if s.isdisjoint(disjoint_sets):
                 disjoint_sets.update(s)

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -217,25 +217,6 @@ class Add(Sequence):
         )
 
     @property
-    def is_pauli_add(self) -> bool:
-        """Check if Add contains only pauli string, that is a weighted
-        sum of tensor products of pauli operators.
-
-        Returns:
-            bool: True if pauli string.
-        """
-        all_leaves_ops: list = list()
-        for op in self.flatten():
-            if isinstance(op, Scale):
-                if isinstance(op.operations[0], Sequence):
-                    all_leaves_ops += op.operations[0].flatten()
-                else:
-                    all_leaves_ops += [op.operations[0]]
-            else:
-                all_leaves_ops.append(op)
-        return all(isinstance(op, PAULI_OPS) for op in all_leaves_ops)  # type: ignore[arg-type]
-
-    @property
     def commuting_terms(self) -> bool:
         """Check if operator can be decomposed into commuting terms."""
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -217,8 +217,8 @@ class Add(Sequence):
         )
 
     @property
-    def is_pauli_string(self) -> bool:
-        """Check if Add is a pauli string, that is a weighted
+    def is_pauli_add(self) -> bool:
+        """Check if Add contains only pauli string, that is a weighted
         sum of tensor products of pauli operators.
 
         Returns:

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -240,10 +240,18 @@ class Add(Sequence):
         """Check if operator can be decomposed into commuting terms."""
 
         # when operators are defined on different qubit supports
-        qubit_supports = [op.qubit_support for op in self.operations]
-        if len(set(qubit_supports)) == len(qubit_supports):
-            return True
+        if len(self.operations) == 1:
+            return False
+        qubit_supports_intersect = [set(op.qubit_support) for op in self.operations]
 
+        disjoint_sets = set()
+        for s in qubit_supports_intersect:
+            if s.isdisjoint(disjoint_sets):
+                disjoint_sets.update(s)
+            else:
+                return False
+        if len(disjoint_sets) == len(self.qubit_support):
+            return True
         return False
 
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -148,7 +148,7 @@ class Scale(Sequence):
 def disjoint_supports(
     operations: ModuleList | list[Module], qubit_support: tuple[int, ...]
 ) -> bool:
-    """Check all operations are defined over different supports.
+    """Check all operations are defined over disjoint supports.
 
     Args:
         operations (ModuleList): Operations.

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -319,10 +319,7 @@ class Add(Sequence):
         if len(self.operations) == 1:
             return False
 
-        if disjoint_supports(self.operations, self.qubit_support):
-            return True
-
-        if self._symplectic_commute():
+        if disjoint_supports(self.operations, self.qubit_support) or self._symplectic_commute():
             return True
 
         return False

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -259,7 +259,7 @@ class Add(Sequence):
 
     def _symplectic_commute(self) -> bool:
         """A predicate to check if operator is composed of communting pauli strings.
-        
+
         Achieved by computing the symplectic inner product from string-based representations.
 
         Reference:
@@ -269,12 +269,12 @@ class Add(Sequence):
 
         if all(isinstance(op, PAULI_OPS) for op in self._flatten()):
             qubit_support = self.qubit_support
-            nb_support = len(qubit_support)
+            n_qubits = len(qubit_support)
             n_strings = len(self.operations)
 
             # build binary representation of pauli operations for symplectic product
             binary_vectors = [
-                (np.zeros(nb_support, dtype=int), np.zeros(nb_support, dtype=int))
+                (np.zeros(n_qubits, dtype=int), np.zeros(n_qubits, dtype=int))
                 for _ in range(n_strings)
             ]
             for ind_op, op in enumerate(self.operations):
@@ -320,7 +320,10 @@ class Add(Sequence):
         if len(self.operations) == 1:
             return False
 
-        if disjoint_supports(self.operations, self.qubit_support) or self._symplectic_commute():
+        if (
+            disjoint_supports(self.operations, self.qubit_support)
+            or self._symplectic_commute()
+        ):
             return True
 
         return False

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -22,7 +22,7 @@ from pyqtorch.utils import (
 from .sequence import Sequence
 
 BATCH_DIM = 2
-PAULI_OPS = [X, Y, Z, I]
+PAULI_OPS = (X, Y, Z, I)
 
 logger = getLogger(__name__)
 
@@ -227,14 +227,12 @@ class Add(Sequence):
         all_leaves_ops: list = list()
         for op in self.flatten():
             if isinstance(op, Scale):
-                all_leaves_ops.append(
-                    op.operations[0].flatten()
-                    if isinstance(op.operations[0], Sequence)
-                    else op.operations[0]
-                )
+                if isinstance(op.operations[0], Sequence):
+                    all_leaves_ops += op.operations[0].flatten()
+                else:
+                    all_leaves_ops += [op.operations[0]]
             else:
                 all_leaves_ops.append(op)
-
         return all(isinstance(op, PAULI_OPS) for op in all_leaves_ops)  # type: ignore[arg-type]
 
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -252,6 +252,9 @@ class Add(Sequence):
                 return False
         if len(disjoint_sets) == len(self.qubit_support):
             return True
+
+        # TODO: pauli hamiltonian cases
+
         return False
 
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -317,7 +317,8 @@ class Add(Sequence):
 
     @property
     def commuting_terms(self) -> bool:
-        """Return if all operations are commuting terms.
+        """Predicate for all operations being composed of commuting terms.
+        
         Useful for HamiltonianEvolution.
         """
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -174,6 +174,9 @@ class Add(Sequence):
         values = values or dict()
         return reduce(add, (op(state, values, embedding) for op in self.operations))
 
+    def _flatten(self) -> ModuleList:
+        return ModuleList([self])
+
     def tensor(
         self,
         values: dict | None = None,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -224,7 +224,9 @@ class Add(Sequence):
         Returns:
             bool: True if pauli string.
         """
-        return all(isinstance(op, PAULI_OPS) for op in self._flatten())
+        if all(isinstance(op, (Scale, Primitive)) for op in self.operations):
+            return all(isinstance(op, PAULI_OPS) for op in self._flatten())
+        return False
 
     def _symplectic_commute(self) -> bool:
         """Check if operator is composed of pauli strings, each commuting with each other."""
@@ -299,7 +301,6 @@ class Add(Sequence):
         # when operators are defined on different qubit supports
         if len(self.operations) == 1:
             return False
-
         if self._symplectic_commute() or self._different_support_operations():
             # if self._different_support_operations():
             return True
@@ -336,6 +337,9 @@ class Merge(Sequence):
             )
 
         self._contains_noise = sum([op.noise is not None for op in self.operations])
+
+    def _flatten(self) -> ModuleList:
+        return ModuleList([self])
 
     def forward(
         self,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -258,8 +258,9 @@ class Add(Sequence):
         )
 
     def _symplectic_commute(self) -> bool:
-        """Check if operator is composed of pauli strings, each commuting with each other.
-        Done by computing the symplectic inner product from the string-based representations.
+        """A predicate to check if operator is composed of communting pauli strings.
+        
+        Achieved by computing the symplectic inner product from string-based representations.
 
         Reference:
             S. Aaronson, D. Gottesman, Improved Simulation of Stabilizer Circuits,

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -301,6 +301,7 @@ class Add(Sequence):
             return False
 
         if self._symplectic_commute() or self._different_support_operations():
+            # if self._different_support_operations():
             return True
 
         return False

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -236,7 +236,7 @@ class Add(Sequence):
         return all(isinstance(op, PAULI_OPS) for op in all_leaves_ops)  # type: ignore[arg-type]
 
     @property
-    def commuting(self) -> bool:
+    def commuting_terms(self) -> bool:
         """Check if operator can be decomposed into commuting terms."""
 
         # when operators are defined on different qubit supports

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -315,10 +315,9 @@ class Add(Sequence):
 
         return False
 
-    @property
     def commuting_terms(self) -> bool:
         """Predicate for all operations being composed of commuting terms.
-        
+
         Useful for HamiltonianEvolution.
         """
 

--- a/pyqtorch/composite/compose.py
+++ b/pyqtorch/composite/compose.py
@@ -235,6 +235,17 @@ class Add(Sequence):
                 all_leaves_ops.append(op)
         return all(isinstance(op, PAULI_OPS) for op in all_leaves_ops)  # type: ignore[arg-type]
 
+    @property
+    def commuting(self) -> bool:
+        """Check if operator can be decomposed into commuting terms."""
+
+        # when operators are defined on different qubit supports
+        qubit_supports = [op.qubit_support for op in self.operations]
+        if len(set(qubit_supports)) == len(qubit_supports):
+            return True
+
+        return False
+
 
 class Merge(Sequence):
     def __init__(

--- a/pyqtorch/composite/sequence.py
+++ b/pyqtorch/composite/sequence.py
@@ -136,6 +136,15 @@ class Sequence(Module):
             self._dtype = self.operations[0].dtype
         return self
 
+    def _flatten(self) -> ModuleList:
+        ops = []
+        for op in self.operations:
+            if isinstance(op, Sequence):
+                ops += op._flatten()
+            else:
+                ops.append(op)
+        return ModuleList(ops)
+
     def flatten(self) -> ModuleList:
         ops = []
         for op in self.operations:

--- a/pyqtorch/composite/sequence.py
+++ b/pyqtorch/composite/sequence.py
@@ -137,7 +137,7 @@ class Sequence(Module):
         return self
 
     def _flatten(self) -> ModuleList:
-        """This method helps for checking commutation of pauli operators, especially for Scale."""
+        """Method helper for checking commutation of pauli operators, especially for Scale."""
         ops = []
         for op in self.operations:
             if isinstance(op, Sequence):

--- a/pyqtorch/composite/sequence.py
+++ b/pyqtorch/composite/sequence.py
@@ -137,6 +137,7 @@ class Sequence(Module):
         return self
 
     def _flatten(self) -> ModuleList:
+        """This method helps for checking commutation of pauli operators, especially for Scale."""
         ops = []
         for op in self.operations:
             if isinstance(op, Sequence):

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -381,7 +381,7 @@ class HamiltonianEvolution(Sequence):
 
     def _generator(
         self,
-        values: dict | None = None,
+        values: dict = dict(),
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
     ) -> Operator:
@@ -398,10 +398,10 @@ class HamiltonianEvolution(Sequence):
         """
         if self._original_generator:
             return self._original_generator.tensor(  # type: ignore [union-attr]
-                values or dict(), embedding, full_support, diagonal=self.is_diagonal
+                values, embedding, full_support, diagonal=self.is_diagonal
             )
         return super().tensor(
-            values or dict(), embedding, full_support, diagonal=self.is_diagonal
+            values, embedding, full_support, diagonal=self.is_diagonal
         )
 
     @property
@@ -470,10 +470,9 @@ class HamiltonianEvolution(Sequence):
     def _forward(
         self,
         state: Tensor,
-        values: dict[str, Tensor] | ParameterDict | None = None,
+        values: dict[str, Tensor] | ParameterDict = dict(),
         embedding: Embedding | None = None,
     ) -> State:
-        values = values or dict()
         if self._original_generator is None:
 
             evolved_op = self.tensor(values, embedding)
@@ -486,7 +485,7 @@ class HamiltonianEvolution(Sequence):
     def _forward_commuting_generators(
         self,
         state: Tensor,
-        values: dict[str, Tensor] | ParameterDict | None = None,
+        values: dict[str, Tensor] | ParameterDict = dict(),
         embedding: Embedding | None = None,
     ) -> State:
         """Apply the hamiltonian evolution with input parameter values when
@@ -500,7 +499,6 @@ class HamiltonianEvolution(Sequence):
         Returns:
             The transformed state.
         """
-        values = values or dict()
         if embedding is not None:
             values = embedding(values)
 
@@ -509,7 +507,7 @@ class HamiltonianEvolution(Sequence):
     def _forward_time(
         self,
         state: Tensor,
-        values: dict[str, Tensor] | ParameterDict | None = None,
+        values: dict[str, Tensor] | ParameterDict = dict(),
         embedding: Embedding = Embedding(),
     ) -> State:
         """Apply the hamiltonian evolution with input parameter values for time dependent cases.
@@ -522,7 +520,6 @@ class HamiltonianEvolution(Sequence):
         Returns:
             The transformed state.
         """
-        values = values or dict()
         n_qubits = len(state.shape) - 1
         batch_size = state.shape[-1]
         duration = (
@@ -662,7 +659,7 @@ class HamiltonianEvolution(Sequence):
 
     def jacobian(
         self,
-        values: dict[str, Tensor] | None = None,
+        values: dict[str, Tensor] = dict(),
         embedding: Embedding | None = None,
     ) -> Tensor:
         """Get the corresponding unitary of the jacobian.
@@ -673,7 +670,6 @@ class HamiltonianEvolution(Sequence):
         Returns:
             The unitary representation of the jacobian.
         """
-        values = values or dict()
         if embedding is not None:
             values = embedding(values)
 

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -271,9 +271,9 @@ class HamiltonianEvolution(Sequence):
 
         self._generator_map: dict[GeneratorType, Callable] = {
             GeneratorType.SYMBOL: self._symbolic_generator,
-            GeneratorType.TENSOR: self._tensor_generator,
-            GeneratorType.OPERATION: self._tensor_generator,
-            GeneratorType.PARAMETRIC_OPERATION: self._tensor_generator,
+            GeneratorType.TENSOR: self._generator,
+            GeneratorType.OPERATION: self._generator,
+            GeneratorType.PARAMETRIC_OPERATION: self._generator,
         }
 
         # to avoid recomputing hamiltonians and evolution
@@ -379,7 +379,7 @@ class HamiltonianEvolution(Sequence):
             return torch.permute(hamiltonian.squeeze(3), (1, 2, 0))
         return hamiltonian
 
-    def _tensor_generator(
+    def _generator(
         self,
         values: dict | None = None,
         embedding: Embedding | None = None,
@@ -447,8 +447,7 @@ class HamiltonianEvolution(Sequence):
         return spectral_gap[spectral_gap.nonzero()]
 
     def _time_evolution(self, values: dict[str, Tensor] | ParameterDict) -> Tensor:
-        """
-        Get the evolution from parameter values.
+        """Get the evolution from parameter values.
 
         Arguments:
             values: Values of parameters.
@@ -490,8 +489,7 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | ParameterDict | None = None,
         embedding: Embedding | None = None,
     ) -> State:
-        """
-        Apply the hamiltonian evolution with input parameter values when
+        """Apply the hamiltonian evolution with input parameter values when
         hamiltonian is composed of commuting terms.
 
         Arguments:
@@ -514,8 +512,7 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | ParameterDict | None = None,
         embedding: Embedding = Embedding(),
     ) -> State:
-        """
-        Apply the hamiltonian evolution with input parameter values for time dependent cases.
+        """Apply the hamiltonian evolution with input parameter values for time dependent cases.
 
         Arguments:
             state: Input state.
@@ -586,8 +583,7 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | ParameterDict | None = None,
         embedding: Embedding | None = None,
     ) -> State:
-        """
-        Apply the hamiltonian evolution with input parameter values.
+        """Apply the hamiltonian evolution with input parameter values.
 
         Arguments:
             state: Input state.
@@ -669,8 +665,7 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | None = None,
         embedding: Embedding | None = None,
     ) -> Tensor:
-        """
-        Get the corresponding unitary of the jacobian.
+        """Get the corresponding unitary of the jacobian.
 
         Arguments:
             values: Parameter value.

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -237,18 +237,6 @@ class HamiltonianEvolution(Sequence):
                     ]
                 self.is_diagonal = generator[0].is_diagonal
                 self.generator_type = GeneratorType.OPERATION
-
-                # # avoiding using dense tensor for diagonal generators
-                # tgen = generator.tensor(diagonal=generator.is_diagonal)
-                # generator = [
-                #     Primitive(
-                #         tgen,
-                #         generator.qubit_support,
-                #         diagonal=(len(tgen.size()) == 2),
-                #     )
-                # ]
-                # self.is_diagonal = generator[0].is_diagonal
-                # self.generator_type = GeneratorType.OPERATION
         else:
             raise TypeError(
                 f"Received generator of type {type(generator)},\
@@ -445,6 +433,15 @@ class HamiltonianEvolution(Sequence):
     def _time_evolution(
         self, values: dict[str, Tensor] | ParameterDict | None = None
     ) -> Tensor:
+        """
+        Get the evolution from parameter values.
+
+        Arguments:
+            values: Values of parameters.
+
+        Returns:
+            The time evolution.
+        """
         values = values or dict()
         if isinstance(self.time, str):
             pname = self.time
@@ -464,6 +461,17 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | ParameterDict | None = None,
         embedding: Embedding | None = None,
     ) -> State:
+        """
+        Apply the hamiltonian evolution with input parameter values.
+
+        Arguments:
+            state: Input state.
+            values: Values of parameters.
+            embedding: Embedding of parameters.
+
+        Returns:
+            The transformed state.
+        """
         values = values or dict()
 
         if len(self.generator) < 2:
@@ -481,6 +489,18 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | ParameterDict | None = None,
         embedding: Embedding | None = None,
     ) -> State:
+        """
+        Apply the hamiltonian evolution with input parameter values when
+        hamiltonian is composed of commuting terms.
+
+        Arguments:
+            state: Input state.
+            values: Values of parameters.
+            embedding: Embedding of parameters.
+
+        Returns:
+            The transformed state.
+        """
         values = values or dict()
         if embedding is not None:
             values = embedding(values)
@@ -522,6 +542,17 @@ class HamiltonianEvolution(Sequence):
         values: dict[str, Tensor] | ParameterDict | None = None,
         embedding: Embedding = Embedding(),
     ) -> State:
+        """
+        Apply the hamiltonian evolution with input parameter values for time dependent cases.
+
+        Arguments:
+            state: Input state.
+            values: Values of parameters.
+            embedding: Embedding of parameters.
+
+        Returns:
+            The transformed state.
+        """
         values = values or dict()
         n_qubits = len(state.shape) - 1
         batch_size = state.shape[-1]
@@ -615,8 +646,12 @@ class HamiltonianEvolution(Sequence):
         To avoid computing the evolution operator, we store it in cache wrt values.
 
         Arguments:
-            values: Parameter value.
-            Can be higher than the number of qubit support.
+            values: Parameter values.
+            embedding (Embedding | None, optional): Optional embedding. Defaults to None.
+            full_support (tuple[int, ...] | None, optional): The qubits the returned tensor
+                will be defined over. Defaults to None for only using the qubit_support.
+            diagonal (bool, optional): Whether to return the diagonal form of the tensor or not.
+                Defaults to False.
 
         Returns:
             The unitary representation.

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -317,8 +317,11 @@ class HamiltonianEvolution(Sequence):
     def is_time_dependent(self) -> bool:
         return self._is_time_dependent(self.generator)
 
-    def flatten(self) -> ModuleList:
+    def _flatten(self) -> ModuleList:
         return ModuleList([self])
+
+    def flatten(self) -> ModuleList:
+        return self._flatten()
 
     @property
     def param_name(self) -> Tensor | str:

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -320,6 +320,7 @@ class HamiltonianEvolution(Sequence):
         self,
         values: dict,
         embedding: Embedding | None = None,
+        full_support: tuple[int, ...] | None = None,
     ) -> Operator:
         """Returns the generator for the SYMBOL case.
 
@@ -345,7 +346,10 @@ class HamiltonianEvolution(Sequence):
         return hamiltonian
 
     def _tensor_generator(
-        self, values: dict | None = None, embedding: Embedding | None = None
+        self,
+        values: dict | None = None,
+        embedding: Embedding | None = None,
+        full_support: tuple[int, ...] | None = None,
     ) -> Operator:
         """Returns the generator for the TENSOR, OPERATION and PARAMETRIC_OPERATION cases.
 
@@ -355,8 +359,8 @@ class HamiltonianEvolution(Sequence):
         Returns:
             The generator as a tensor.
         """
-        return self.generator[0].tensor(
-            values or dict(), embedding, diagonal=self.is_diagonal
+        return super().tensor(
+            values or dict(), embedding, full_support, diagonal=self.is_diagonal
         )
 
     @property
@@ -378,7 +382,7 @@ class HamiltonianEvolution(Sequence):
         Returns:
             Eigenvalues of the operation.
         """
-
+        
         return self.generator[0].eigenvalues
 
     @cached_property
@@ -439,8 +443,7 @@ class HamiltonianEvolution(Sequence):
                 values[self.time] = torch.as_tensor(t)
                 reembedded_time_values = values
             return (
-                self.generator[0]
-                .tensor(
+                self._tensor_generator(
                     reembedded_time_values,
                     embedding,
                     full_support=tuple(range(n_qubits)),

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -214,7 +214,6 @@ class HamiltonianEvolution(Sequence):
                 if is_parametric(generator)
                 else GeneratorType.OPERATION
             )
-            self.is_diagonal = generator.is_diagonal
             original_generator = generator
             generator = [
                 HamiltonianEvolution(
@@ -230,6 +229,7 @@ class HamiltonianEvolution(Sequence):
                 )
                 for op in generator.operations
             ]
+            self.is_diagonal = all(gen.is_diagonal for gen in generator)
 
         elif isinstance(generator, (QuantumOperation, Sequence)):
             qubit_support = generator.qubit_support

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -382,7 +382,7 @@ class HamiltonianEvolution(Sequence):
         embedding: Embedding | None = None,
         full_support: tuple[int, ...] | None = None,
     ) -> Operator:
-        """Returns the generator for the TENSOR, OPERATION and PARAMETRIC_OPERATION cases.
+        """Returns the TENSOR, OPERATION and PARAMETRIC_OPERATION generator.
 
         Arguments:
             values: Values dict with any needed parameters.

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -208,7 +208,9 @@ class HamiltonianEvolution(Sequence):
             self.generator_type = GeneratorType.SYMBOL
             self.generator_symbol = generator
             generator = []
-        elif noise is None and isinstance(generator, Add) and generator.commuting_terms:
+        elif (
+            noise is None and isinstance(generator, Add) and generator.commuting_terms()
+        ):
             qubit_support = generator.qubit_support
             self.generator_type = (
                 GeneratorType.PARAMETRIC_OPERATION

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -364,7 +364,7 @@ class HamiltonianEvolution(Sequence):
         )
 
     @property
-    def create_hamiltonian(self) -> Callable[[dict], Operator]:
+    def create_hamiltonian(self) -> Callable:
         """A utility method for setting the right generator getter depending on the init case.
 
         Returns:
@@ -382,7 +382,7 @@ class HamiltonianEvolution(Sequence):
         Returns:
             Eigenvalues of the operation.
         """
-        blockmat = self._tensor_generator()
+        blockmat = self.create_hamiltonian()
         if len(blockmat.shape) == 3:
             return torch.linalg.eigvals(blockmat.permute((2, 0, 1))).reshape(-1, 1)
         else:
@@ -446,7 +446,7 @@ class HamiltonianEvolution(Sequence):
             else:
                 values[self.time] = torch.as_tensor(t)
                 reembedded_time_values = values
-            return self._tensor_generator(
+            return self.create_hamiltonian(
                 reembedded_time_values,
                 embedding,
                 full_support=tuple(range(n_qubits)),

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -235,7 +235,7 @@ class HamiltonianEvolution(Sequence):
                             diagonal=(len(tgen.size()) == 2),
                         )
                     ]
-                self.is_diagonal = generator[0].is_diagonal
+                self.is_diagonal = all(g.is_diagonal for g in generator)
                 self.generator_type = GeneratorType.OPERATION
         else:
             raise TypeError(

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -446,9 +446,7 @@ class HamiltonianEvolution(Sequence):
         spectral_gap = torch.unique(torch.abs(torch.tril(diffs)))
         return spectral_gap[spectral_gap.nonzero()]
 
-    def _time_evolution(
-        self, values: dict[str, Tensor] | ParameterDict | None = None
-    ) -> Tensor:
+    def _time_evolution(self, values: dict[str, Tensor] | ParameterDict) -> Tensor:
         """
         Get the evolution from parameter values.
 
@@ -458,7 +456,6 @@ class HamiltonianEvolution(Sequence):
         Returns:
             The time evolution.
         """
-        values = values or dict()
         if isinstance(self.time, str):
             pname = self.time
             # note: GPSR trick when the same param_name is used in many operations

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -214,17 +214,7 @@ class HamiltonianEvolution(Sequence):
                 self.generator_type = GeneratorType.PARAMETRIC_OPERATION
             else:
                 if isinstance(generator, Add) and generator.commuting_terms:
-                    # avoiding using dense tensor for diagonal generators
-                    primitives = [
-                        op.tensor(diagonal=generator.is_diagonal)
-                        for op in generator.operations
-                    ]
-                    generator = [
-                        Primitive(
-                            tgen, op.qubit_support, diagonal=(len(tgen.size()) == 2)
-                        )
-                        for tgen, op in zip(primitives, generator.operations)
-                    ]
+                    generator = generator.operations
                 else:
                     # avoiding using dense tensor for diagonal generators
                     tgen = generator.tensor(diagonal=generator.is_diagonal)

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -172,6 +172,7 @@ class HamiltonianEvolution(Sequence):
         self.duration = duration
         self.use_sparse = use_sparse
         self.is_diagonal = False
+        self._param_uuid = str(uuid4())
         original_generator = None
 
         if isinstance(duration, (str, float, Tensor)) or duration is None:
@@ -229,6 +230,8 @@ class HamiltonianEvolution(Sequence):
                 )
                 for op in generator.operations
             ]
+            for gen in generator:
+                gen._param_uuid = self._param_uuid
             self.is_diagonal = all(gen.is_diagonal for gen in generator)
 
         elif isinstance(generator, (QuantumOperation, Sequence)):
@@ -284,8 +287,6 @@ class HamiltonianEvolution(Sequence):
                 "as HamiltonianEvolution."
             )
         self.noise = noise
-
-        self._param_uuid = str(uuid4())
 
     @property
     def generator(self) -> ModuleList:

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -220,13 +220,12 @@ class HamiltonianEvolution(Sequence):
                 HamiltonianEvolution(
                     op,
                     time,
-                    op.qubit_support,
-                    cache_length,
-                    duration,
-                    steps,
-                    solver,
-                    use_sparse,
-                    noise,
+                    cache_length=cache_length,
+                    duration=duration,
+                    steps=steps,
+                    solver=solver,
+                    use_sparse=use_sparse,
+                    noise=noise,
                 )
                 for op in generator.operations
             ]

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -356,7 +356,10 @@ class HamiltonianEvolution(Sequence):
         """Returns the generator for the SYMBOL case.
 
         Arguments:
-            values:
+            values: Values dict with any needed parameters.
+            embedding: Embedding of parameters.
+            full_support: The qubits the returned tensor
+                will be defined over. Defaults to None for only using the qubit_support.
 
         Returns:
             The generator as a tensor.
@@ -386,6 +389,9 @@ class HamiltonianEvolution(Sequence):
 
         Arguments:
             values: Values dict with any needed parameters.
+            embedding: Embedding of parameters.
+            full_support: The qubits the returned tensor
+                will be defined over. Defaults to None for only using the qubit_support.
 
         Returns:
             The generator as a tensor.
@@ -445,8 +451,10 @@ class HamiltonianEvolution(Sequence):
     ) -> Tensor:
         """
         Get the evolution from parameter values.
+
         Arguments:
             values: Values of parameters.
+
         Returns:
             The time evolution.
         """
@@ -488,10 +496,12 @@ class HamiltonianEvolution(Sequence):
         """
         Apply the hamiltonian evolution with input parameter values when
         hamiltonian is composed of commuting terms.
+
         Arguments:
             state: Input state.
             values: Values of parameters.
             embedding: Embedding of parameters.
+
         Returns:
             The transformed state.
         """
@@ -509,10 +519,12 @@ class HamiltonianEvolution(Sequence):
     ) -> State:
         """
         Apply the hamiltonian evolution with input parameter values for time dependent cases.
+
         Arguments:
             state: Input state.
             values: Values of parameters.
             embedding: Embedding of parameters.
+
         Returns:
             The transformed state.
         """

--- a/pyqtorch/hamiltonians/evolution.py
+++ b/pyqtorch/hamiltonians/evolution.py
@@ -629,6 +629,8 @@ class HamiltonianEvolution(Sequence):
             and values_cache_key in self._cache_hamiltonian_evo
         ):
             evolved_op = self._cache_hamiltonian_evo[values_cache_key]
+        elif len(self.generator) > 1:
+            return super().tensor(values, embedding, full_support, use_diagonal)
         else:
             hamiltonian: torch.Tensor = self.create_hamiltonian(values, embedding)  # type: ignore [call-arg]
             time_evolution = self._time_evolution(values)

--- a/pyqtorch/primitives/primitive_gates.py
+++ b/pyqtorch/primitives/primitive_gates.py
@@ -33,7 +33,6 @@ class X(MutablePrimitive):
             target,
             noise=noise,
         )
-        self.name = "X"
 
     def _mutate_state_vector(self, state: Tensor) -> Tensor:
         #  X gate flips the values at the specified dimension
@@ -48,7 +47,6 @@ class Y(MutablePrimitive):
     ):
         super().__init__(OPERATIONS_DICT["Y"], target, noise=noise)
         self.modifier = self._apply_phases
-        self.name = "Y"
 
     def _apply_phases(self, state: Tensor) -> Tensor:
         state = torch.flip(state, dims=[0])
@@ -65,7 +63,6 @@ class Z(PhaseMutablePrimitive):
         noise: DigitalNoiseProtocol | None = None,
     ):
         super().__init__(OPERATIONS_DICT["Z"], target, noise=noise)
-        self.name = "Z"
 
 
 class I(Primitive):  # noqa: E742
@@ -75,7 +72,6 @@ class I(Primitive):  # noqa: E742
         noise: DigitalNoiseProtocol | None = None,
     ):
         super().__init__(OPERATIONS_DICT["I"], target, noise=noise)
-        self.name = "I"
 
     def _forward(
         self,

--- a/pyqtorch/primitives/primitive_gates.py
+++ b/pyqtorch/primitives/primitive_gates.py
@@ -33,6 +33,7 @@ class X(MutablePrimitive):
             target,
             noise=noise,
         )
+        self.name = "X"
 
     def _mutate_state_vector(self, state: Tensor) -> Tensor:
         #  X gate flips the values at the specified dimension
@@ -47,6 +48,7 @@ class Y(MutablePrimitive):
     ):
         super().__init__(OPERATIONS_DICT["Y"], target, noise=noise)
         self.modifier = self._apply_phases
+        self.name = "Y"
 
     def _apply_phases(self, state: Tensor) -> Tensor:
         state = torch.flip(state, dims=[0])
@@ -63,6 +65,7 @@ class Z(PhaseMutablePrimitive):
         noise: DigitalNoiseProtocol | None = None,
     ):
         super().__init__(OPERATIONS_DICT["Z"], target, noise=noise)
+        self.name = "Z"
 
 
 class I(Primitive):  # noqa: E742
@@ -72,6 +75,7 @@ class I(Primitive):  # noqa: E742
         noise: DigitalNoiseProtocol | None = None,
     ):
         super().__init__(OPERATIONS_DICT["I"], target, noise=noise)
+        self.name = "I"
 
     def _forward(
         self,

--- a/tests/differentiation/test_differentiation.py
+++ b/tests/differentiation/test_differentiation.py
@@ -104,11 +104,19 @@ def test_adjoint_diff(n_qubits: int, n_layers: int) -> None:
 @pytest.mark.parametrize("n_qubits", [3, 4, 5])
 @pytest.mark.parametrize("n_layers", [1, 2, 3])
 @pytest.mark.parametrize("diagonal", [True, False])
-def test_adjoint_diff_hamevo(n_qubits: int, n_layers: int, diagonal: bool) -> None:
+@pytest.mark.parametrize("commuting_terms", [False, True])
+def test_adjoint_diff_hamevo(
+    n_qubits: int, n_layers: int, diagonal: bool, commuting_terms: bool
+) -> None:
 
     cnot = pyq.CNOT(1, 2)
     ham = random_pauli_hamiltonian(
-        n_qubits, k_1q=n_qubits, k_2q=0, default_scale_coeffs=1.0, diagonal=diagonal
+        n_qubits,
+        k_1q=n_qubits,
+        k_2q=0,
+        default_scale_coeffs=1.0,
+        diagonal=diagonal,
+        commuting_terms=commuting_terms,
     )[0]
     ham_op = pyq.HamiltonianEvolution(ham, "t", qubit_support=tuple(range(n_qubits)))
     ops = [ham_op, cnot] * n_layers

--- a/tests/differentiation/test_gpsr.py
+++ b/tests/differentiation/test_gpsr.py
@@ -109,7 +109,9 @@ def circuit_sequence(n_qubits: int, different_names: bool = True) -> QuantumCirc
 
 
 def circuit_hamevo_tensor_gpsr(
-    n_qubits: int, different_names: bool = True
+    n_qubits: int,
+    different_names: bool = True,
+    commuting_terms: bool = False,  # unused here
 ) -> QuantumCircuit:
     """Helper function to make an example circuit."""
 
@@ -136,12 +138,16 @@ def circuit_hamevo_tensor_gpsr(
 
 
 def circuit_hamevo_pauligen_gpsr(
-    n_qubits: int, different_names: bool = True
+    n_qubits: int, different_names: bool = True, commuting_terms: bool = False
 ) -> QuantumCircuit:
     """Helper function to make an example circuit."""
 
     ham = random_pauli_hamiltonian(
-        n_qubits, k_1q=n_qubits, k_2q=0, default_scale_coeffs=1.0
+        n_qubits,
+        k_1q=n_qubits,
+        k_2q=0,
+        default_scale_coeffs=1.0,
+        commuting_terms=commuting_terms,
     )[0]
     ham_op = pyq.HamiltonianEvolution(ham, "t", qubit_support=tuple(range(n_qubits)))
 
@@ -173,18 +179,23 @@ def circuit_hamevo_pauligen_gpsr(
     ],
 )
 @pytest.mark.parametrize("different_names", [False, True])
+@pytest.mark.parametrize("commuting_terms", [False, True])
 def test_expectation_gpsr_hamevo(
     n_qubits: int,
     batch_size: int,
     circuit_fn: Callable,
     different_names: bool,
+    commuting_terms: bool,
     dtype: torch.dtype = torch.complex128,
 ) -> None:
     torch.manual_seed(42)
-    circ = circuit_fn(n_qubits, different_names).to(dtype)
+    circ = circuit_fn(n_qubits, different_names, commuting_terms).to(dtype)
     obs = Observable(
         random_pauli_hamiltonian(
-            n_qubits, k_1q=n_qubits, k_2q=0, default_scale_coeffs=1.0
+            n_qubits,
+            k_1q=n_qubits,
+            k_2q=0,
+            default_scale_coeffs=1.0,
         )[0]
     ).to(dtype)
     values = {
@@ -268,7 +279,10 @@ def test_expectation_gpsr(
     circ = circuit_fn(n_qubits, different_names).to(dtype)
     obs = Observable(
         random_pauli_hamiltonian(
-            n_qubits, k_1q=n_qubits, k_2q=0, default_scale_coeffs=1.0
+            n_qubits,
+            k_1q=n_qubits,
+            k_2q=0,
+            default_scale_coeffs=1.0,
         )[0]
     ).to(dtype)
     values = {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -105,6 +105,7 @@ def random_pauli_hamiltonian(
     default_scale_coeffs: float | None = None,
     p_param: float = 0.5,
     diagonal: bool = False,
+    commuting_terms: bool = False,
 ) -> tuple[Sequence, list]:
     """Creates a random Pauli Hamiltonian as a sum of k_1q + k_2q terms.
 
@@ -121,11 +122,18 @@ def random_pauli_hamiltonian(
         tuple[Sequence, list]: Hamiltonian and list of parameters.
     """
     OPS_PAULI_choice = list(OPS_PAULI) if not diagonal else [I, Z]
+    if commuting_terms:
+        k_1q = n_qubits
+        k_2q = 0
     one_q_terms: list = random.choices(OPS_PAULI_choice, k=k_1q)
+
     two_q_terms: list = [random.choices(OPS_PAULI_choice, k=2) for _ in range(k_2q)]
     terms: list = []
-    for term in one_q_terms:
-        supp = random.sample(range(n_qubits), 1)
+    for i, term in enumerate(one_q_terms):
+        if commuting_terms:
+            supp = [i]
+        else:
+            supp = random.sample(range(n_qubits), 1)
         terms.append(term(supp))
     for term in two_q_terms:
         supp = random.sample(range(n_qubits), 2)

--- a/tests/noise/test_noise.py
+++ b/tests/noise/test_noise.py
@@ -279,10 +279,15 @@ def test_noise_circ(
 @pytest.mark.parametrize("make_param", [True, False])
 @pytest.mark.parametrize("n_qubits", [4, 5])
 @pytest.mark.parametrize("batch_size", [1, 5])
-def test_dm_expectation(n_qubits: int, batch_size: int, make_param: bool) -> None:
+@pytest.mark.parametrize("commuting_terms", [False, True])
+def test_dm_expectation(
+    n_qubits: int, batch_size: int, make_param: bool, commuting_terms: bool
+) -> None:
     k_1q = 2 * n_qubits  # Number of 1-qubit terms
     k_2q = n_qubits**2  # Number of 2-qubit terms
-    hamiltonian, param_list = random_pauli_hamiltonian(n_qubits, k_1q, k_2q, make_param)
+    hamiltonian, param_list = random_pauli_hamiltonian(
+        n_qubits, k_1q, k_2q, make_param, commuting_terms=commuting_terms
+    )
     values = {param: torch.rand(batch_size) for param in param_list}
     psi_init = random_state(n_qubits, batch_size)
     dm_init = density_mat(psi_init)

--- a/tests/primitives/test_tensor.py
+++ b/tests/primitives/test_tensor.py
@@ -350,9 +350,15 @@ def test_hevo_pauli_tensor(
             assert operator.is_diagonal
 
     if make_param:
-        assert operator.generator_type == GeneratorType.PARAMETRIC_OPERATION
+        assert operator.generator_type in (
+            GeneratorType.PARAMETRIC_OPERATION,
+            GeneratorType.PARAMETRIC_COMMUTING_SEQUENCE,
+        )
     else:
-        assert operator.generator_type == GeneratorType.OPERATION
+        assert operator.generator_type in (
+            GeneratorType.OPERATION,
+            GeneratorType.COMMUTING_SEQUENCE,
+        )
     values[tparam] = torch.rand(batch_size)
     psi_star = operator(psi_init, values)
     psi_expected = calc_mat_vec_wavefunction(operator, psi_init, values, full_support)

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -435,6 +435,8 @@ def test_hamevo_parametric_gen(
     generator, param_list = random_pauli_hamiltonian(
         n_qubits, k_1q, k_2q, make_param=make_param, p_param=1.0
     )
+    assert generator.is_pauli_add
+
     tparam = "t"
 
     param_list.append("t")

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -426,11 +426,12 @@ def test_error_noise_qubit_support(
 
 @pytest.mark.parametrize("n_qubits", [2, 4, 6])
 @pytest.mark.parametrize("batch_size", [1, 2])
-def test_hamevo_parametric_gen(n_qubits: int, batch_size: int) -> None:
+@pytest.mark.parametrize("make_param", [True, False])
+def test_hamevo_parametric_gen(n_qubits: int, batch_size: int, make_param: bool) -> None:
     k_1q = 2 * n_qubits  # Number of 1-qubit terms
     k_2q = n_qubits**2  # Number of 2-qubit terms
     generator, param_list = random_pauli_hamiltonian(
-        n_qubits, k_1q, k_2q, make_param=True, p_param=1.0
+        n_qubits, k_1q, k_2q, make_param=make_param, p_param=1.0
     )
     assert generator.is_pauli_add
 
@@ -440,7 +441,10 @@ def test_hamevo_parametric_gen(n_qubits: int, batch_size: int) -> None:
 
     hamevo = pyq.HamiltonianEvolution(generator, tparam, cache_length=2)
 
-    assert hamevo.generator_type == GeneratorType.PARAMETRIC_OPERATION
+    if make_param:
+        assert hamevo.generator_type == GeneratorType.PARAMETRIC_OPERATION
+    else:
+        assert hamevo.generator_type == GeneratorType.OPERATION
     assert len(hamevo._cache_hamiltonian_evo) == 0
 
     def apply_hamevo_and_compare_expected(psi, values):

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -432,7 +432,7 @@ def test_hamevo_parametric_gen(n_qubits: int, batch_size: int) -> None:
     generator, param_list = random_pauli_hamiltonian(
         n_qubits, k_1q, k_2q, make_param=True, p_param=1.0
     )
-    assert generator.is_pauli_string
+    assert generator.is_pauli_add
 
     tparam = "t"
 

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -427,7 +427,9 @@ def test_error_noise_qubit_support(
 @pytest.mark.parametrize("n_qubits", [2, 4, 6])
 @pytest.mark.parametrize("batch_size", [1, 2])
 @pytest.mark.parametrize("make_param", [True, False])
-def test_hamevo_parametric_gen(n_qubits: int, batch_size: int, make_param: bool) -> None:
+def test_hamevo_parametric_gen(
+    n_qubits: int, batch_size: int, make_param: bool
+) -> None:
     k_1q = 2 * n_qubits  # Number of 1-qubit terms
     k_2q = n_qubits**2  # Number of 2-qubit terms
     generator, param_list = random_pauli_hamiltonian(

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -432,6 +432,7 @@ def test_hamevo_parametric_gen(n_qubits: int, batch_size: int) -> None:
     generator, param_list = random_pauli_hamiltonian(
         n_qubits, k_1q, k_2q, make_param=True, p_param=1.0
     )
+    assert generator.is_pauli_string
 
     tparam = "t"
 

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -435,8 +435,6 @@ def test_hamevo_parametric_gen(
     generator, param_list = random_pauli_hamiltonian(
         n_qubits, k_1q, k_2q, make_param=make_param, p_param=1.0
     )
-    assert generator.is_pauli_add
-
     tparam = "t"
 
     param_list.append("t")

--- a/tests/test_analog.py
+++ b/tests/test_analog.py
@@ -448,9 +448,15 @@ def test_hamevo_parametric_gen(
     hamevo = pyq.HamiltonianEvolution(generator, tparam, cache_length=2)
 
     if make_param:
-        assert hamevo.generator_type == GeneratorType.PARAMETRIC_OPERATION
+        assert hamevo.generator_type in (
+            GeneratorType.PARAMETRIC_OPERATION,
+            GeneratorType.PARAMETRIC_COMMUTING_SEQUENCE,
+        )
     else:
-        assert hamevo.generator_type == GeneratorType.OPERATION
+        assert hamevo.generator_type in (
+            GeneratorType.OPERATION,
+            GeneratorType.COMMUTING_SEQUENCE,
+        )
     assert len(hamevo._cache_hamiltonian_evo) == 0
 
     def apply_hamevo_and_compare_expected(psi, values):

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -70,6 +70,9 @@ def test_add() -> None:
 
 
 def test_add_commute() -> None:
+    op = pyq.Add([pyq.Z(0)])
+    assert not op.commuting_terms
+
     op = pyq.Add([pyq.Z(q) for q in range(5)])
     assert op._disjoint_supports()
     assert op.commuting_terms

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -69,6 +69,22 @@ def test_add() -> None:
     assert torch.allclose(tensor_add, dense_diagonal)
 
 
+def test_add_commute() -> None:
+    op = pyq.Add([pyq.Z(q) for q in range(5)])
+    assert op._disjoint_supports()
+    assert op.commuting_terms
+
+    op = pyq.Add([pyq.Merge([pyq.Z(0), pyq.X(0)]), pyq.Z(1)])
+    assert op._disjoint_supports()
+    assert not op._symplectic_commute()
+    assert op.commuting_terms
+
+    op = pyq.Add([pyq.Sequence([pyq.Z(0), pyq.X(0)]), pyq.Z(1)])
+    assert op._disjoint_supports()
+    assert not op._symplectic_commute()
+    assert op.commuting_terms
+
+
 def test_merge() -> None:
     ops = [pyq.RX(0, "theta_0"), pyq.RY(0, "theta_1"), pyq.RX(0, "theta_2")]
     circ = pyq.QuantumCircuit(2, ops)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -71,21 +71,21 @@ def test_add() -> None:
 
 def test_add_commute() -> None:
     op = pyq.Add([pyq.Z(0)])
-    assert not op.commuting_terms
+    assert not op.commuting_terms()
 
     op = pyq.Add([pyq.Z(q) for q in range(5)])
     assert op._disjoint_supports()
-    assert op.commuting_terms
+    assert op.commuting_terms()
 
     op = pyq.Add([pyq.Merge([pyq.Z(0), pyq.X(0)]), pyq.Z(1)])
     assert op._disjoint_supports()
     assert not op._symplectic_commute()
-    assert op.commuting_terms
+    assert op.commuting_terms()
 
     op = pyq.Add([pyq.Sequence([pyq.Z(0), pyq.X(0)]), pyq.Z(1)])
     assert op._disjoint_supports()
     assert not op._symplectic_commute()
-    assert op.commuting_terms
+    assert op.commuting_terms()
 
 
 def test_merge() -> None:

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -74,16 +74,13 @@ def test_add_commute() -> None:
     assert not op.commuting_terms()
 
     op = pyq.Add([pyq.Z(q) for q in range(5)])
-    assert op._disjoint_supports()
     assert op.commuting_terms()
 
     op = pyq.Add([pyq.Merge([pyq.Z(0), pyq.X(0)]), pyq.Z(1)])
-    assert op._disjoint_supports()
     assert not op._symplectic_commute()
     assert op.commuting_terms()
 
     op = pyq.Add([pyq.Sequence([pyq.Z(0), pyq.X(0)]), pyq.Z(1)])
-    assert op._disjoint_supports()
     assert not op._symplectic_commute()
     assert op.commuting_terms()
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -126,7 +126,6 @@ def test_reembedding() -> None:
     ) and np.allclose(reembedded_results[0], reembedded_results[2], atol=ATOL_embedding)
 
 
-@pytest.mark.skip(reason="Test fail mysteriously for 3.11 in CI")
 def test_sample_run_expectation_grads_with_embedding() -> None:
     name0, fn0 = "fn0", ConcretizedCallable("sin", ["x"])
     name1, fn1 = "fn1", ConcretizedCallable("mul", ["fn0", "y"])

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -126,8 +126,8 @@ def test_reembedding() -> None:
     ) and np.allclose(reembedded_results[0], reembedded_results[2], atol=ATOL_embedding)
 
 
-@pytest.mark.parametrize("diff_mode", [pyq.DiffMode.AD])
-def test_sample_run_expectation_grads_with_embedding(diff_mode) -> None:
+@pytest.mark.skip(reason="Test fail mysteriously for 3.11 in CI")
+def test_sample_run_expectation_grads_with_embedding() -> None:
     name0, fn0 = "fn0", ConcretizedCallable("sin", ["x"])
     name1, fn1 = "fn1", ConcretizedCallable("mul", ["fn0", "y"])
     name2, fn2 = "fn2", ConcretizedCallable("mul", ["fn1", 2.0])
@@ -157,11 +157,11 @@ def test_sample_run_expectation_grads_with_embedding(diff_mode) -> None:
     wf = pyq.run(circ, state, values_ad, embedding)
     samples = pyq.sample(circ, state, values_ad, 100, embedding)
     exp_ad = pyq.expectation(
-        circ, state, values_ad, obs, diff_mode, embedding=embedding
+        circ, state, values_ad, obs, pyq.DiffMode.AD, embedding=embedding
     )
     assert torch.autograd.gradcheck(
         lambda x, y: pyq.expectation(
-            circ, state, {"x": x, "y": y}, obs, diff_mode, embedding=embedding
+            circ, state, {"x": x, "y": y}, obs, pyq.DiffMode.AD, embedding=embedding
         ),
         (x, y),
         atol=1e-1,  # torch.autograd.gradcheck is very susceptible to small numerical errors


### PR DESCRIPTION
Solves #177 by:

- [x] Adding checks for commuting terms in the `Add` operator, so cases with different supports and commuting pauli-strings
- [x] Handling the `Add` case with commuting terms when initialising `HamiltonianEvolution`
- [x] Using a `Sequence` of `HamiltonianEvolution` from commuting terms, and modifying `HamiltonianEvolution` methods such as `forward`, `tensor`
- [x] Add commuting cases in tests